### PR TITLE
Fixed #78: php oil test complains PHPUnit is not installed

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -121,6 +121,7 @@ class Command
 
 				case 't':
 				case 'test':
+					include_once('PHPUnit/Autoload.php');
 
 					// Attempt to load PUPUnit.  If it fails, we are done.
 					if ( ! class_exists('PHPUnit_Framework_TestCase'))


### PR DESCRIPTION
Refer to http://dev.fuelphp.com/issues/78
