### PR TITLE
\Inflector::classify() assume parameter string is in plural, assigning $singular might cause improper result

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -65,6 +65,7 @@ class Command
 
 					switch ($action)
 					{
+						case 'config':
 						case 'controller':
 						case 'model':
 						case 'views':

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -99,7 +99,7 @@ CONF;
 
 		if (!$overwrite && is_file($path))
 		{
-			throw new Exception("app/config/{$file}.php already exist, please use -overwrite option to force update");
+			throw new Exception("APPPATH/config/{$file}.php already exist, please use -overwrite option to force update");
 		}
 		
 		$path = pathinfo($path);
@@ -107,11 +107,11 @@ CONF;
 		try
 		{
 			\File::update($path['dirname'], $path['basename'], $content);
-			\Cli::write("app/config/{$file}.php created.", 'green');
+			\Cli::write("Created config: APPPATH/config/{$file}.php", 'green');
 		}
 		catch (\File_Exception $e)
 		{
-			throw new Exception("app/config/{$file}.php could not be written.");
+			throw new Exception("APPPATH/config/{$file}.php could not be written.");
 		}
 	}
 

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -54,11 +54,13 @@ class Generate
 			}
 		}
 		
+		unset($path);
+		
 		// We always pass in fields to a config, so lets sort them out here.
 		foreach ($args as $conf)
 		{
 			// Each paramater for a config is seperated by the : character
-			$parts = explode(":", $field);
+			$parts = explode(":", $conf);
 
 			// We must have the 'name:value' if nothing else!
 			if (count($parts) >= 2)
@@ -66,6 +68,8 @@ class Generate
 				$config[$parts[0]] = $parts[1];
 			}
 		}
+		
+		$overwrite = \Cli::option('o') || \Cli::option('overwrite');
 		
 		$content = <<<CONF
 <?php
@@ -91,18 +95,23 @@ CONF;
 /* End of file $file.php */
 CONF;
 
-		($path = \Fuel::find_file('config', $file, '.php')) or $path = APPPATH.'config'.DS.$file.'.php';
+		$path = APPPATH.'config'.DS.$file.'.php';
 
+		if (!$overwrite && is_file($path))
+		{
+			throw new Exception("app/config/{$file}.php already exist, please use -overwrite option to force update");
+		}
+		
 		$path = pathinfo($path);
 		
 		try
 		{
-			File::update($path['dirname'], $path['basename'], $content);
-			\Cli::write("app/config/{$name}.php created.", 'green');
+			\File::update($path['dirname'], $path['basename'], $content);
+			\Cli::write("app/config/{$file}.php created.", 'green');
 		}
 		catch (\File_Exception $e)
 		{
-			throw new Exception("app/config/{$name}.php could not be written.");
+			throw new Exception("app/config/{$file}.php could not be written.");
 		}
 	}
 

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -34,6 +34,25 @@ class Generate
 		'char' => 255,
 		'int' => 11
 	);
+	
+	public static function config($args, $build = true)
+	{
+		$args = self::_clear_args($args);
+		$name = strtolower(array_shift($args));
+		// load the config
+		\Config::load($name, true);
+		$config = \Config::get($name, array ());
+		
+		try
+		{
+			\Config::save($name, $config);
+			\Cli::write("app/config/{$name}.php created.", 'green');
+		}
+		catch (\File_Exception $e)
+		{
+			throw new Exception("app/config/{$name}.php could not be written.");
+		}
+	}
 
 	public static function controller($args, $build = true)
 	{

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -38,14 +38,66 @@ class Generate
 	public static function config($args, $build = true)
 	{
 		$args = self::_clear_args($args);
-		$name = strtolower(array_shift($args));
+		$file = strtolower(array_shift($args));
+		
+		$config = array();
+		
 		// load the config
-		\Config::load($name, true);
-		$config = \Config::get($name, array ());
+		if ($paths = \Fuel::find_file('config', $file, '.php', true))
+		{
+			// Reverse the file list so that we load the core configs first and
+			// the app can override anything.
+			$paths = array_reverse($paths);
+			foreach ($paths as $path)
+			{
+				$config = \Fuel::load($path) + $config;
+			}
+		}
+		
+		// We always pass in fields to a config, so lets sort them out here.
+		foreach ($args as $conf)
+		{
+			// Each paramater for a config is seperated by the : character
+			$parts = explode(":", $field);
+
+			// We must have the 'name:value' if nothing else!
+			if (count($parts) >= 2)
+			{
+				$config[$parts[0]] = $parts[1];
+			}
+		}
+		
+		$content = <<<CONF
+<?php
+/**
+ * Fuel
+ *
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ *
+ * @package		Fuel
+ * @version		1.0
+ * @author		Fuel Development Team
+ * @license		MIT License
+ * @copyright	2011 Fuel Development Team
+ * @link		http://fuelphp.com
+ */
+
+
+CONF;
+		$content .= 'return '.str_replace('  ', "\t", var_export($config, true)).';';
+		$content .= <<<CONF
+
+
+/* End of file $file.php */
+CONF;
+
+		($path = \Fuel::find_file('config', $file, '.php')) or $path = APPPATH.'config'.DS.$file.'.php';
+
+		$path = pathinfo($path);
 		
 		try
 		{
-			\Config::save($name, $config);
+			File::update($path['dirname'], $path['basename'], $content);
 			\Cli::write("app/config/{$name}.php created.", 'green');
 		}
 		catch (\File_Exception $e)

--- a/classes/scaffold.php
+++ b/classes/scaffold.php
@@ -55,8 +55,8 @@ class Scaffold
 		}
 
 		$data['singular'] = $singular = strtolower(array_shift($args));
-		$data['model'] = $model_name = 'Model_'.\Inflector::classify($singular);
 		$data['plural'] = $plural = \Inflector::pluralize($singular);
+		$data['model'] = $model_name = 'Model_'.\Inflector::classify($plural);
 		$data['fields'] = $fields;
 
 		$filepath = APPPATH.'classes/controller/'.trim(str_replace(array('_', '-'), DS, $plural), DS).'.php';


### PR DESCRIPTION
\Inflector::classify() assume parameter string is in plural, assigning $singular might cause improper result:

e.g: $singular = 'campus';
It will return model as 'Model_Campu'
