### PR TITLE
Added support for generated controllers that are in folders, slashes converted to underscores

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -44,7 +44,7 @@ class Generate
 		$filepath = APPPATH . 'classes/controller/'.trim(str_replace(array('_', '-'), DS, $singular), DS).'.php';
 
 		// Uppercase each part of the class name and remove hyphens
-		$class_name = static::class_name($singular);
+		$class_name = str_replace('/', '_', static::class_name($singular));
 
 		// Stick "blogs" to the start of the array
 		array_unshift($args, $singular);


### PR DESCRIPTION
I was generating controllers from command line.   Many of them were in directories (ie app/manager).  The forward slash was included in the controller name.  I added a str_replace to remove a forward slash so that the controller is named correctly (ie Controller_App_Manager).  It throws an exception anyway if there is a forward slash.
