### PR TITLE
Don't try to encode object passed through to set_global

### DIFF
--- a/views/default/scaffold/actions/edit.php
+++ b/views/default/scaffold/actions/edit.php
@@ -21,7 +21,7 @@
 		
 		else
 		{
-			$this->template->set_global('<?php echo $singular; ?>', $<?php echo $singular; ?>);
+			$this->template->set_global('<?php echo $singular; ?>', $<?php echo $singular; ?>, false);
 		}
 		
 		$this->template->title = "<?php echo ucfirst($plural); ?>";


### PR DESCRIPTION
The code generated by the scaffold uses set_global on $this->template of the controller. This passes through an instance of the model and attempts to escape it, thus converting it to string. This fails a security check and causes an exception to be thrown.

This seems to be because auto_encode is true by default and oil does not set the encode parameter to false in the set_global().
