### PR TITLE
A simple change to _form.php to use more native code

### DIFF
--- a/views/default/scaffold/views/_form.php
+++ b/views/default/scaffold/views/_form.php
@@ -2,8 +2,9 @@
 
 <?php foreach ($fields as $field): ?>
 	<p>
-		<label for="<?php echo $field['name']; ?>"><?php echo \Inflector::humanize($field['name']); ?>:</label>
 		<?php
+			echo "<?php echo Form::label('". \Inflector::humanize($field['name'] ."', '{$field['name']}'); ?>\n";
+
 			switch($field['type']):
 
 				case 'text':


### PR DESCRIPTION
I was reviewing the code generated when scaffolding and I noticed that instead of utilizing Form::label() the code was generating hard coded HTML instead. I figured it would be better set using the Form::label() and have updated as so.
