### PR TITLE
Tweak to avoid throwing an error when a task is run more than once in a single PHP session

### DIFF
--- a/classes/refine.php
+++ b/classes/refine.php
@@ -62,7 +62,7 @@ class Refine
 			return;
 		}
 
-		require $file;
+		require_once $file;
 
 		$task = '\\Fuel\\Tasks\\'.$task;
 


### PR DESCRIPTION
If  you run a task multiple times without exiting your PHP session then the compiler will throw an error about declaring the task class again.

```
Compile Error - Cannot redeclare class Fuel\Tasks\Robots in APPPATH/tasks/robots.php on line 27
```
