### PR TITLE
'php oil generate config name' now will allow us to copy config from core

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -63,6 +63,7 @@ class Command
 
 					switch ($action)
 					{
+						case 'config':
 						case 'controller':
 						case 'model':
 						case 'views':

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -67,7 +67,7 @@ class Generate
 			}
 		}
 		
-		$overwrite = \Cli::option('o') || \Cli::option('overwrite');
+		$overwrite = \Cli::option('o') or \Cli::option('overwrite');
 		
 		$content = <<<CONF
 <?php

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -32,6 +32,84 @@ class Generate
 		'char' => 255,
 		'int' => 11
 	);
+	
+	public static function config($args, $build = true)
+	{
+		$args = self::_clear_args($args);
+		$file = strtolower(array_shift($args));
+		
+		$config = array();
+		
+		// load the config
+		if ($paths = \Fuel::find_file('config', $file, '.php', true))
+		{
+			// Reverse the file list so that we load the core configs first and
+			// the app can override anything.
+			$paths = array_reverse($paths);
+			foreach ($paths as $path)
+			{
+				$config = \Fuel::load($path) + $config;
+			}
+		}
+		
+		unset($path);
+		
+		// We always pass in fields to a config, so lets sort them out here.
+		foreach ($args as $conf)
+		{
+			// Each paramater for a config is seperated by the : character
+			$parts = explode(":", $conf);
+
+			// We must have the 'name:value' if nothing else!
+			if (count($parts) >= 2)
+			{
+				$config[$parts[0]] = $parts[1];
+			}
+		}
+		
+		$overwrite = \Cli::option('o') || \Cli::option('overwrite');
+		
+		$content = <<<CONF
+<?php
+/**
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ *
+ * @package		Fuel
+ * @version		1.0
+ * @author		Fuel Development Team
+ * @license		MIT License
+ * @copyright	2011 Fuel Development Team
+ * @link		http://fuelphp.com
+ */
+
+
+CONF;
+		$content .= 'return '.str_replace('  ', "\t", var_export($config, true)).';';
+		$content .= <<<CONF
+
+
+/* End of file $file.php */
+CONF;
+
+		$path = APPPATH.'config'.DS.$file.'.php';
+
+		if (!$overwrite and is_file($path))
+		{
+			throw new Exception("APPPATH/config/{$file}.php already exist, please use -overwrite option to force update");
+		}
+		
+		$path = pathinfo($path);
+		
+		try
+		{
+			\File::update($path['dirname'], $path['basename'], $content);
+			\Cli::write("Created config: APPPATH/config/{$file}.php", 'green');
+		}
+		catch (\File_Exception $e)
+		{
+			throw new Exception("APPPATH/config/{$file}.php could not be written.");
+		}
+	}
 
 	public static function controller($args, $build = true)
 	{

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -105,9 +105,13 @@ CONF;
 			\File::update($path['dirname'], $path['basename'], $content);
 			\Cli::write("Created config: APPPATH/config/{$file}.php", 'green');
 		}
-		catch (\FileException $e)
+		catch (\InvalidPathException $e)
 		{
-			throw new Exception("APPPATH/config/{$file}.php could not be written.");
+			throw new Exception("Invalid basepath, cannot update at ".APPPATH."config".DS."{$file}.php");
+		}
+		catch (\FileAccessException $e)
+		{ 
+			throw new Exception(APPPATH."config".DS.$file.".php could not be written.");
 		}
 	}
 

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -93,7 +93,7 @@ CONF;
 
 		$path = APPPATH.'config'.DS.$file.'.php';
 
-		if (!$overwrite and is_file($path))
+		if ( ! $overwrite and is_file($path))
 		{
 			throw new Exception("APPPATH/config/{$file}.php already exist, please use -overwrite option to force update");
 		}
@@ -105,7 +105,7 @@ CONF;
 			\File::update($path['dirname'], $path['basename'], $content);
 			\Cli::write("Created config: APPPATH/config/{$file}.php", 'green');
 		}
-		catch (\File_Exception $e)
+		catch (\FileException $e)
 		{
 			throw new Exception("APPPATH/config/{$file}.php could not be written.");
 		}


### PR DESCRIPTION
Let user generate config file right from oil.
1. Generate new config file
   `php oil g config sample hello:world`
2. Copy existing config from CORE
   `php oil g config session`
3. Combine config from both APP and CORE (forced update)
   `php oil g config session -overwrite`

Documentation on https://github.com/fuel/docs/pull/171
