### PR TITLE
Pluralization issue when using php oil generate controller

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -36,20 +36,18 @@ class Generate
 	public static function controller($args, $build = true)
 	{
 		$args = self::_clear_args($args);
-		$singular = strtolower(array_shift($args));
+		$base_name = strtolower(array_shift($args));
 		$actions = $args;
 		
-		$plural = \Inflector::pluralize($singular);
-		
-		$filename = trim(str_replace(array('_', '-'), DS, $plural), DS);
+		$filename = trim(str_replace(array('_', '-'), DS, $base_name), DS);
 
 		$filepath = APPPATH . 'classes/controller/'.$filename.'.php';
 
 		// Uppercase each part of the class name and remove hyphens
-		$class_name = \Inflector::classify($plural, false);
+		$class_name = \Inflector::classify($base_name, false);
 
 		// Stick "blogs" to the start of the array
-		array_unshift($args, $plural);
+		array_unshift($args, $base_name);
 
 		// Create views folder and each view file
 		static::views($args, false);
@@ -62,8 +60,8 @@ class Generate
 			$action_str .= '
 	public function action_'.$action.'()
 	{
-		$this->template->title = \'' . \Inflector::humanize($singular) .' &raquo; ' . \Inflector::humanize($action) . '\';
-		$this->template->content = View::factory(\''.$singular .'/' . $action .'\');
+		$this->template->title = \'' . \Inflector::humanize($base_name) .' &raquo; ' . \Inflector::humanize($action) . '\';
+		$this->template->content = View::factory(\''.$base_name .'/' . $action .'\');
 	}'.PHP_EOL;
 		}
 


### PR DESCRIPTION
**Example of issue:**

php oil generate controller test index

**Expected result:**
- fuel/app/classes/controller/test.php is created
- fuel/app/views/test/index.php is created
- Controller name is Controller_Test

**Actual result:**

Note the pluralization:
- fuel/app/classes/controller/tests.php is created
- fuel/app/views/tests/index.php is created
- Controller name is Controller_Tests

**Change proposal:**

When generating only a controller (i.e. - not using scaffold), Oil should respect the name that the user entered. Sometimes they will want a singular name (app, auth, etc.), and sometimes a plural one (users, pages, etc.), and Oil should not try to modify what they entered.

I do feel that the auto pluralization makes perfect sense when using scaffold for generation, as you are supposed to specify the singular version (for a model). This change will not affect that behavior.

Thoughts?
