### PR TITLE
Migration generator will overwrite created_at and updated_at fields

### DIFF
--- a/classes/generate/migration/actions.php
+++ b/classes/generate/migration/actions.php
@@ -32,7 +32,8 @@ class Generate_Migration_Actions
 	public static function create($subjects, $fields)
 	{
 		$field_str = '';
-		
+		$defined_columns = array();
+
 		foreach($fields as $field)
 		{
 			$name = array_shift($field);
@@ -58,7 +59,8 @@ class Generate_Migration_Actions
 			}
 			$field_opts = implode(', ', $field_opts);
 			
-			$field_str .= "\t\t\t'$name' => array({$field_opts}),".PHP_EOL;			
+			$field_str .= "\t\t\t'$name' => array({$field_opts}),".PHP_EOL;
+			$defined_columns[$name] = true;
 		}
 		
 		// ID Field
@@ -66,8 +68,16 @@ class Generate_Migration_Actions
 
 		if ( ! \Cli::option('no-timestamps', false))
 		{
-			$field_str .= "\t\t\t'created_at' => array('constraint' => 11, 'type' => 'int'),";
-			$field_str .= PHP_EOL."\t\t\t'updated_at' => array('constraint' => 11, 'type' => 'int'),";
+			if ( ! isset($defined_columns['created_at']))
+			{
+				$field_str .= "\t\t\t'created_at' => array('constraint' => 11, 'type' => 'int'),".PHP_EOL;
+			}
+
+			if ( ! isset($definied_columns['updated_at']))
+			{
+				$field_str .= "\t\t\t'updated_at' => array('constraint' => 11, 'type' => 'int'),";
+			}
+
 		}
 
 		$up = <<<UP


### PR DESCRIPTION
When going through the documentation I ran "php oil g model post title:varchar[50] body:text user_id:int created_at:datetime". The generated migration is:

``` php
<?php

namespace Fuel\Migrations;

class Create_posts {

    public function up()
    {
        \DBUtil::create_table('posts', array(
            'id' => array('constraint' => 11, 'type' => 'int', 'auto_increment' => true),
            'title' => array('constraint' => 50, 'type' => 'varchar'),
            'body' => array('type' => 'text'),
            'user_id' => array('constraint' => 11, 'type' => 'int'),
            'created_at' => array('type' => 'datetime'),
            'created_at' => array('constraint' => 11, 'type' => 'int'),
            'updated_at' => array('constraint' => 11, 'type' => 'int'),
        ), array('id'));
    }

    public function down()
    {
        \DBUtil::drop_table('posts');
    }
}
```

As you can see, 'created_at' is declared twice, the second time overwriting the user's command line declaration. 
