### PR TITLE
php oil generate config to support config generation in modules

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -84,7 +84,7 @@ CONF;
 /* End of file $file.php */
 CONF;
 		
-		$module = \Cli::option('module');
+		$module = \Cli::option('module', \Cli::option('m'));
 		
 		// get the namespace path (if available)
 		if ( ! empty($module) and $path = \Autoloader::namespace_path('\\'.ucfirst($module)))

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -71,8 +71,6 @@ class Generate
 
 		// strip whitespace and add tab
 		$export = str_replace(array('  ', 'array ('), array("\t", 'array('), var_export($config, true));
-		// strip out the key of numeric array
-		$export = preg_replace("/(\d{1,10})\s=>\s/", "", $export);
 
 		$content = <<<CONF
 <?php

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -549,6 +549,7 @@ Examples:
   php oil g migration <migrationname> [<fieldname1>:<type1> |<fieldname2>:<type2> |..]
   php oil g scaffold <modelname> [<fieldname1>:<type1> |<fieldname2>:<type2> |..]
   php oil g scaffold/template_subfolder <modelname> [<fieldname1>:<type1> |<fieldname2>:<type2> |..]
+  php oil g config <filename> [<key1>:<value1> |<key2>:<value2> |..]
 
 Note that the next two lines are equivalent:
   php oil g scaffold <modelname> ...


### PR DESCRIPTION
```
php oil generate config foo bar:name --module=admin
```

Now allow user to create `modules/admin/config/foo.php` in admin module instead of just the default `APPPATH`.

Some other minor changes:
- use the same str_replace as `Fuel\Core\Config::save()`
- throws exception indicate `APPPATH` or module name.
- add -m shortcut (follow `Fuel\Core\Migrate` structure)
