### PR TITLE
Update 'php oil g model --orm' to generate proper Class name and Update default Observer

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -226,8 +226,14 @@ MODEL;
 				$contents = <<<CONTENTS
 	
 	protected static \$_observers = array(
-		'Orm\Observer_CreatedAt' => array('before_insert'),
-		'Orm\Observer_UpdatedAt' => array('before_save'),
+		'Orm\Observer_CreatedAt' => array(
+			'events' => array('before_insert'),
+			'mysql_timestamp' => false,
+		),
+		'Orm\Observer_UpdatedAt' => array(
+			'events' => array('before_save'),
+			'mysql_timestamp' => false,
+		),
 	);
 CONTENTS;
 			}

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -235,7 +235,7 @@ CONTENTS;
 			$model = <<<MODEL
 <?php
 
-class {$class_name} extends \Orm\Model
+class Model_{$class_name} extends \Orm\Model
 {
 {$contents}
 }

--- a/views/orm/scaffold/model.php
+++ b/views/orm/scaffold/model.php
@@ -17,8 +17,14 @@ class Model_<?php echo $model_class; ?> extends Model
 
 <?php if ($include_timestamps): ?>
 	protected static $_observers = array(
-		'Orm\Observer_CreatedAt' => array('before_insert'),
-		'Orm\Observer_UpdatedAt' => array('before_save'),
+		'Orm\Observer_CreatedAt' => array(
+			'events' => array('before_insert'),
+			'mysql_timestamp' => false,
+		),
+		'Orm\Observer_UpdatedAt' => array(
+			'events' => array('before_save'),
+			'mysql_timestamp' => false,
+		),
 	);
 <?php endif; ?>
 


### PR DESCRIPTION
- Currently the generated class name doesn't use either Model_ Prefix or Model namespace, I guess the best way is to use Model_ prefix (as how it was done previously and how scaffold/orm does it now)
- Update `Observer_CreatedAt` and `Observer_UpdatedAt` in model generation to follow latest structure in fuel/orm (see http://fuelphp.com/dev-docs/packages/orm/observers/included.html#os_created)
