### PR TITLE
Allow to automatically generate a list of properties using php oil genera

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -221,7 +221,7 @@ MODEL;
 		{
 			// Go through all arguments after the first and make them into field arrays
 			$fields = array();
-			foreach (array_slice($args, 1) as $arg)
+			foreach ($args as $arg)
 			{
 				// Parse the argument for each field in a pattern of name:type[constraint]
 				preg_match('/([a-z0-9_]+):([a-z0-9_]+)(\[([0-9]+)\])?/i', $arg, $matches);

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -219,10 +219,29 @@ MODEL;
 		}
 		else
 		{
+			// Go through all arguments after the first and make them into field arrays
+			$fields = array();
+			foreach (array_slice($args, 1) as $arg)
+			{
+				// Parse the argument for each field in a pattern of name:type[constraint]
+				preg_match('/([a-z0-9_]+):([a-z0-9_]+)(\[([0-9]+)\])?/i', $arg, $matches);
+
+				array_push($fields, \Str::lower($matches[1]));
+			}
+			
 			$contents = '';
 
 			if ( ! \Cli::option('no-timestamp', false)) 
 			{
+				// Only add created_at or updated_at when it not passed as an arguments
+				foreach(array('created_at', 'updated_at') as $field)
+				{
+					if ( ! in_array($field, $fields))
+					{
+						array_push($fields, $field);
+					}
+				}
+
 				$contents = <<<CONTENTS
 	
 	protected static \$_observers = array(
@@ -237,6 +256,32 @@ MODEL;
 	);
 CONTENTS;
 			}
+
+			// Add id as the default primary key
+			if ( ! in_array('id', $fields))
+			{
+				array_unshift($fields, 'id');
+			}
+
+			// Start generate properties list
+			$field_contents = '';
+
+			foreach ($fields as $field)
+			{
+				if (empty($field))
+				{
+					continue;
+				}
+
+				$field_contents .= "\t\t'{$field}',".PHP_EOL;
+			}
+
+			$contents = <<<CONTENTS
+	protected static \$_properties = array(
+{$field_contents}
+	);
+{$contents}
+CONTENTS;
 
 			$model = <<<MODEL
 <?php


### PR DESCRIPTION
Allow to automatically generate a list of properties using php oil generate model --orm
## Example

```
php oil g model event name:string description:text start_date:date end_date:date --orm 
```

will generate

```

<?php

class Model_Event extends \Orm\Model
{
    protected static $_properties = array(
        'id',
        'name',
        'description',
        'start_date',
        'end_date',
        'created_at',
        'updated_at',

    );

    protected static $_observers = array(
        'Orm\Observer_CreatedAt' => array(
            'events' => array('before_insert'),
            'mysql_timestamp' => false,
        ),
        'Orm\Observer_UpdatedAt' => array(
            'events' => array('before_save'),
            'mysql_timestamp' => false,
        ),
    );
}
```

It's a modification of how `php oil generate scaffold/orm` create a model
