### PR TITLE
Modification to use the new method find() with parameter all

### DIFF
--- a/views/crud/scaffold/actions/index.php
+++ b/views/crud/scaffold/actions/index.php
@@ -1,3 +1,3 @@
-		$data['<?php echo $plural_name ?>'] = Model_<?php echo $model_class; ?>::find_all();
+		$data['<?php echo $plural_name ?>'] = Model_<?php echo $model_class; ?>::find('all');
 		$this->template->title = "<?php echo ucfirst($plural_name); ?>";
 		$this->template->content = View::forge('<?php echo $view_path ?>/index', $data);


### PR DESCRIPTION
When you use the oil to generate scaffold code, the code generated uses find_all() method, returning a error.
