### PR TITLE
throw an error if no config name specified, removed not used variable build

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -33,10 +33,15 @@ class Generate
 		'int' => 11
 	);
 
-	public static function config($args, $build = true)
+	public static function config($args)
 	{
 		$args = self::_clear_args($args);
 		$file = strtolower(array_shift($args));
+
+		if ( ! $file)
+		{
+			throw new Exception('No config name was provided.');
+		}
 
 		$config = array();
 


### PR DESCRIPTION
throw an error if no config name specified, removed variable: $build  (not used in method config)
