### PR TITLE
Allow to add constraint for enum (multiple select value) and decimal 

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -427,7 +427,7 @@ VIEW;
 						$field_array['name'] = array_shift($parts);
 						foreach ($parts as $part_i => $part)
 						{
-							preg_match('/([a-z0-9_-]+)(?:\[([a-z0-9]+)\])?/i', $part, $part_matches);
+							preg_match('/([a-z0-9_-]+)(?:\[([0-9a-z\,\s]+)\])?/i', $part, $part_matches);
 							array_shift($part_matches);
 
 							if (count($part_matches) < 1)
@@ -464,7 +464,24 @@ VIEW;
 									}
 									else
 									{
-										$field_array['constraint'] = (int) $option[1];
+										// should support field_name:enum[value1,value2]
+										if ($type === 'enum')
+										{
+											$values = explode(',', $option[1]);
+											$option[1] = '"'.implode('","', $values).'"';
+
+											$field_array['constraint'] = $option[1];
+										}
+										// should support field_name:decimal[10,2]
+										elseif (in_array($type, array('decimal', 'float')))
+										{
+											$field_array['constraint'] = $option[1];
+										}
+										else
+										{
+											$field_array['constraint'] = (int) $option[1];
+										}
+										
 									}
 								}
 								$option = $type;


### PR DESCRIPTION
Allow to add constraint for enum (multiple select value) and decimal (value with floating point)
## Example

```
php oil g migration create_users username:string[100] status:enum[unverified,verified] status1:decimal[10] status2:float[10,2] status3:enum[1]
```

will generate 

```
<?php

namespace Fuel\Migrations;

class Create_users {

    public function up()
    {
        \DBUtil::create_table('users', array(
            'id' => array('constraint' => 11, 'type' => 'int', 'auto_increment' => true),
            'username' => array('constraint' => 100, 'type' => 'varchar'),
            'status' => array('constraint' => '"unverified","verified"', 'type' => 'enum'),
            'status1' => array('constraint' => '10', 'type' => 'decimal'),
            'status2' => array('constraint' => '10,2', 'type' => 'float'),
            'status3' => array('constraint' => '"1"', 'type' => 'enum'),
            'created_at' => array('constraint' => 11, 'type' => 'int'),
            'updated_at' => array('constraint' => 11, 'type' => 'int'),
        ), array('id'));
    }

    public function down()
    {
        \DBUtil::drop_table('users');
    }
}
```

Signed-off-by: crynobone crynobone@gmail.com
