### PR TITLE
Add created_at and updated_at to properties list

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -207,6 +207,13 @@ CONTROLLER;
 		$class_name = \Inflector::classify($singular, false);
 
 		$contents = '';
+
+		$timestamp_properties = array();
+
+		if ( ! \Cli::option('no-timestamp'))
+		{
+			$timestamp_properties = array('created_at:int', 'updated_at:int');
+		}
 		
 		// Turn foo:string into "id", "foo",
 		$properties = implode(",\n\t\t", array_map(function($field) {
@@ -217,7 +224,7 @@ CONTROLLER;
 				return "'".$field."'";
 			}
 			
-		}, array_merge(array('id:int'), $args)));
+		}, array_merge(array('id:int'), $args, $timestamp_properties)));
 		
 		if ( ! \Cli::option('no-properties')) 
 		{


### PR DESCRIPTION
Using `php oil g model foo bar:string --orm` will generate

```
<?php

class Model_Foo extends \Orm\Model
{
    protected static $_properties = array(
        'id',
        'bar',
        'created_at',
        'updated_at'
    );

    protected static $_observers = array(
        'Orm\Observer_CreatedAt' => array(
            'events' => array('before_insert'),
            'mysql_timestamp' => false,
        ),
        'Orm\Observer_UpdatedAt' => array(
            'events' => array('before_save'),
            'mysql_timestamp' => false,
        ),
    );
}
```

Signed-off-by: crynobone crynobone@gmail.com
