### PR TITLE
Dealing with @ symbols in oil

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -94,7 +94,9 @@ class Command
 				case 'refine':
 
 					// Developers of third-party tasks may not be displaying PHP errors. Report any error and quit
-					set_error_handler(function($errno, $errstr, $errfile, $errline){
+					set_error_handler(function($errno, $errstr, $errfile, $errline) {
+						if (!error_reporting()) return; // If the error was supressed with an @ then we ignore it!
+						
 						\Cli::error("Error: {$errstr} in $errfile on $errline");
 						\Cli::beep();
 						exit;


### PR DESCRIPTION
Currently the oil error handler didn't care about the php @ symbol for suppressing errors, now it does, as per the documentation here: http://php.net/manual/en/function.set-error-handler.php
