### PR TITLE
Remove duplicate code

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -91,13 +91,6 @@ CONF;
 		{
 			list($module, $file) = explode('::', $file);
 		}
-
-		if (strpos($file, '::') !== false)
-		{
-			$fragment = explode('::', $file);
-			$module = $fragment[0];
-			$file = $fragment[1];
-		}
 		
 		// get the namespace path (if available)
 		if ( ! empty($module) and $path = \Autoloader::namespace_path('\\'.ucfirst($module)))


### PR DESCRIPTION
Sorry for this, but I accidentally run the same action twice.

```
    if (strpos($file, '::') !== false)
    {
        list($module, $file) = explode('::', $file);
    }
```

and 

```
    if (strpos($file, '::') !== false)
    {
        $fragment = explode('::', $file);
        $module = $fragment[0];
        $file = $fragment[1];
    }
```

does the same thing.

Signed-off-by: crynobone crynobone@gmail.com
