### PR TITLE
Changing default subfolder value to crud

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -47,7 +47,7 @@ class Command
 
 					$action = isset($args[2]) ? $args[2]: 'help';
 
-					$subfolder = 'orm';
+					$subfolder = 'crud';
 					if (is_int(strpos($action, '/')))
 					{
 						list($action, $subfolder)=explode('/', $action);


### PR DESCRIPTION
Shouldn't the subfolder value be 'crud' by default, since with orm we need to enable an additionnal package ? Also the current value is in contradiction with comments on file generate.php on line 614-615 where we can read that php oil g scaffold <modelname> and php oil g scaffold/crud <modelname> are equivalent...
