### PR TITLE
Check For a Custom phpunit.xml Before Using Default

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -167,8 +167,18 @@ class Command
 						throw new Exception('PHPUnit does not appear to be installed.'.PHP_EOL.PHP_EOL."\tPlease visit http://phpunit.de and install.");
 					}
 
-					// CD to the root of Fuel and call up phpunit with a path to our config
-					$command = 'cd '.DOCROOT.'; phpunit -c "'.COREPATH.'phpunit.xml"';
+					// Check for a custom phpunit config, but default to the one from core
+					if (file_exists(APPPATH.'phpunit.xml'))
+					{
+						$phpunit_config = APPPATH.'phpunit.xml';
+					}
+					else
+					{
+						$phpunit_config = COREPATH.'phpunit.xml';
+					}
+
+					// CD to the root of Fuel and call up phpunit with the path to our config
+					$command = 'cd '.DOCROOT.'; phpunit -c "'.$phpunit_config.'"';
 
 					// Respect the group option
 					\Cli::option('group') and $command .= ' --group '.\Cli::option('group');


### PR DESCRIPTION
This pull request will allow devs to provide their own custom phpunit.xml config file.  It defaults to using the existing COREPATH phpunit.xml, but checks for an APPPATH phpunit.xml first.  To customize the test config, you can simply copy fuel/phpunit.xml to your app directory and modify that. 

This eliminates the problem of requiring you to create a custom fork of the fuel core subrepo to track your changes to the phpunit config.
1. This follows Fuel's existing 'extension' file pattern. And since it defaults to using the existing phpunit.xml, it should not break anybody's existing project.
2. This will allow you to change the environment variables set in phpunit.xml and track those changes with your app.
3. You'll now be able to add a custom test suite and track it with your app.  For example, if your project has modules, it makes sense to keep the unit test code inside those modules, so you can add a test suite for the path `../app/modules/*/tests`, or wherever your modules are kept for your project.
4. To make the phpunit.xml file completely copy-and-paste friendly, the bootstrap reference in the phpunit tag needs to change from `bootstrap_phpunit.php` to `../fuel/bootstrap_phpunit.php`.  (This seems okay to me, since the `fuel/` path is already hardcoded in three of the four following lines.)  If you think this would be a good thing to do, let me know and I'll file a pull request for this on core.

BTW, this is my first-ever attempt to contribute to someone else's project; please be patient with me if I'm doing it wrong! Thanks for your time and consideration.  
