### PR TITLE
Feature: Oil command confirmation

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -23,6 +23,8 @@ class Command
 {
 	public static function init($args)
 	{
+    \Config::load('oil', true);
+    
 		//set up the environment
 		if (($env = \Cli::option('env')))
 		{
@@ -45,6 +47,13 @@ class Command
 				static::help();
 				return;
 			}
+      
+      //Should we prompt user before continuing?
+      if (in_array($args[1], \Config::get('oil.confirm_commands', array())) and (isset($args[2]) ? $args[2]: '') != 'help')
+      {
+        $confirm = \Cli::prompt('Are you sure you wish to proceed?', array('n', 'y'));
+        if ($confirm === 'n') return;
+      }
 
 			switch ($args[1])
 			{

--- a/config/oil.php
+++ b/config/oil.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ *
+ * @package    Fuel
+ * @version    1.0
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2012 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+/**
+ * NOTICE:
+ *
+ * If you need to make modifications to the default configuration, copy
+ * this file to your app/config folder, and make them in there.
+ *
+ * This will allow you to upgrade fuel without losing your custom config.
+ */
+
+ return array(
+   //prompt for confirmation before completing the command
+   'confirm_commands' => array(
+     //'g',
+     //'generate',
+   ),
+ );


### PR DESCRIPTION
Adds the option, through a configuration file, to have a confirmation
prompt appear prior to executing specified Oil commands.

https://github.com/fuel/oil/issues/121
