### PR TITLE
fix build_date() to work on Windows

### DIFF
--- a/classes/console.php
+++ b/classes/console.php
@@ -206,7 +206,7 @@ class Console
 		ob_end_clean();
 
 		$x = strip_tags($x);
-		$x = explode(PHP_EOL, $x);
+		$x = explode("\n", $x);	// PHP_EOL doesn't work on Windows
 		$s = array('Build Date => ', 'Build Date ');
 
 		foreach ($x as $i)


### PR DESCRIPTION
Current:
`Fuel 1.2 - PHP 5.3.8 (cli) (???) [WINNT]`

This patch:
`Fuel 1.2 - PHP 5.3.8 (cli) (Aug 23 2011 11:47:20) [WINNT]`
