### PR TITLE
Fixed module path not being found in refine for already loaded modules

### DIFF
--- a/classes/refine.php
+++ b/classes/refine.php
@@ -45,7 +45,8 @@ class Refine
 		{
 			try
 			{
-				$path = \Module::load($module);
+				\Module::load($module);
+				$path = \Module::exists($module);
 				\Finder::instance()->add_path($path);
 			}
 			catch (\FuelException $e)


### PR DESCRIPTION
Refine was expecting to get the path back from the `\Module::load()` method but this does not return the path, so changed it to use `\Module::exists()` to get the path
