### PR TITLE
Bugfix: For 'oil generate scaffold' & 'oil generate admin'.

### DIFF
--- a/views/admin/crud/actions/create.php
+++ b/views/admin/crud/actions/create.php
@@ -22,7 +22,7 @@
 			}
 			else
 			{
-				Session::set_flash('error', $val->show_errors());
+				Session::set_flash('error', $val->error());
 			}
 		}
 

--- a/views/admin/crud/actions/edit.php
+++ b/views/admin/crud/actions/edit.php
@@ -22,7 +22,7 @@
 			}
 			else
 			{
-				Session::set_flash('error', $val->show_errors());
+				Session::set_flash('error', $val->error());
 			}
 		}
 

--- a/views/admin/orm/actions/create.php
+++ b/views/admin/orm/actions/create.php
@@ -24,7 +24,7 @@
 			}
 			else
 			{
-				Session::set_flash('error', $val->show_errors());
+				Session::set_flash('error', $val->error());
 			}
 		}
 

--- a/views/admin/orm/actions/edit.php
+++ b/views/admin/orm/actions/edit.php
@@ -28,7 +28,7 @@
 				$<?php echo $singular_name; ?>-><?php echo $field['name']; ?> = $val->validated('<?php echo $field['name']; ?>');
 <?php endforeach; ?>
 
-				Session::set_flash('error', $val->show_errors());
+				Session::set_flash('error', $val->error());
 			}
 			
 			$this->template->set_global('<?php echo $singular_name; ?>', $<?php echo $singular_name; ?>, false);

--- a/views/scaffolding/crud/actions/create.php
+++ b/views/scaffolding/crud/actions/create.php
@@ -22,7 +22,7 @@
 			}
 			else
 			{
-				Session::set_flash('error', $val->show_errors());
+				Session::set_flash('error', $val->error());
 			}
 		}
 

--- a/views/scaffolding/crud/actions/edit.php
+++ b/views/scaffolding/crud/actions/edit.php
@@ -24,7 +24,7 @@
 			}
 			else
 			{
-				Session::set_flash('error', $val->show_errors());
+				Session::set_flash('error', $val->error());
 			}
 		}
 

--- a/views/scaffolding/orm/actions/create.php
+++ b/views/scaffolding/orm/actions/create.php
@@ -24,7 +24,7 @@
 			}
 			else
 			{
-				Session::set_flash('error', $val->show_errors());
+				Session::set_flash('error', $val->error());
 			}
 		}
 

--- a/views/scaffolding/orm/actions/edit.php
+++ b/views/scaffolding/orm/actions/edit.php
@@ -31,7 +31,7 @@
 				$<?php echo $singular_name; ?>-><?php echo $field['name']; ?> = $val->validated('<?php echo $field['name']; ?>');
 <?php endforeach; ?>
 
-				Session::set_flash('error', $val->show_errors());
+				Session::set_flash('error', $val->error());
 			}
 
 			$this->template->set_global('<?php echo $singular_name; ?>', $<?php echo $singular_name; ?>, false);

--- a/views/scaffolding/template.php
+++ b/views/scaffolding/template.php
@@ -17,14 +17,14 @@
 <?php if (Session::get_flash('success')): ?>
 				<div class="alert-message success">
 					<p>
-					<?php echo implode('</p><p>', (array) Session::get_flash('success')); ?>
+					<?php echo implode('</p><p>', e((array) Session::get_flash('success'))); ?>
 					</p>
 				</div>
 <?php endif; ?>
 <?php if (Session::get_flash('error')): ?>
 				<div class="alert-message error">
 					<p>
-					<?php echo implode('</p><p>', (array) Session::get_flash('error')); ?>
+					<?php echo implode('</p><p>', e((array) Session::get_flash('error'))); ?>
 					</p>
 				</div>
 <?php endif; ?>


### PR DESCRIPTION
Validation error messages doesn't reflected bootstrap css style when 'oil generate scaffold'.
Validation error messages force html escaped when 'oil generate admin'.
ul tag enters the p tag when generate scaffold.
## 

This is the another way for https://github.com/fuel/oil/pull/128
