### PR TITLE
1.3/develop

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -784,7 +784,7 @@ HELP;
 		$glob = glob(APPPATH .'migrations/*_*.php');
 		list($last) = explode('_', basename(end($glob)));
 
-		return str_pad($last + 1, 3, '0', STR_PAD_LEFT);
+		return time();
 	}
 
 	private static function _update_current_version($version)

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -781,9 +781,6 @@ HELP;
 
 	private static function _find_migration_number()
 	{
-		$glob = glob(APPPATH .'migrations/*_*.php');
-		list($last) = explode('_', basename(end($glob)));
-
 		return time();
 	}
 


### PR DESCRIPTION
While dealing with collisions on migration script numbers across branches it seemed to be a good idea to change the migration number to use a time stamp which should ensure the number is consecutive, current and unique to another developer creating migrations when on another branch.
