### PR TITLE
Add support for clover, text and phpformat Code Coverage to 'test' function to mirror full phpunit options

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -179,6 +179,9 @@ class Command
 
 					// Respect the coverage-html option
 					\Cli::option('coverage-html') and $command .= ' --coverage-html '.\Cli::option('coverage-html');
+					\Cli::option('coverage-clover') and $command .= ' --coverage-clover '.\Cli::option('coverage-clover');
+					\Cli::option('coverage-text') and $command .= ' --coverage-text='.\Cli::option('coverage-text');
+					\Cli::option('coverage-php') and $command .= ' --coverage-php '.\Cli::option('coverage-php');
 
 					\Cli::write('Tests Running...This may take a few moments.', 'green');
 


### PR DESCRIPTION
Support the three extra command line arguments that phpunit supports for clover, text and php formatted reports.
