### PR TITLE
Configurable PHPUnit Paths

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -23,6 +23,8 @@ class Command
 {
 	public static function init($args)
 	{
+		\Config::load('oil', true);
+		
 		// Remove flag options from the main argument list
 		$args = self::_clear_args($args);
 
@@ -154,7 +156,8 @@ class Command
 
 					// Suppressing this because if the file does not exist... well thats a bad thing and we can't really check
 					// I know that supressing errors is bad, but if you're going to complain: shut up. - Phil
-					@include_once('PHPUnit/Autoload.php');
+					$phpunit_autoload_path = \Config::get('oil.phpunit.autoload_path', 'PHPUnit/Autoload.php' );
+					@include_once($phpunit_autoload_path);
 
 					// Attempt to load PHUnit.  If it fails, we are done.
 					if ( ! class_exists('PHPUnit_Framework_TestCase'))
@@ -173,7 +176,8 @@ class Command
 					}
 
 					// CD to the root of Fuel and call up phpunit with the path to our config
-					$command = 'cd '.DOCROOT.'; phpunit -c "'.$phpunit_config.'"';
+					$phpunit_command = \Config::get('oil.phpunit.binary_path', 'phpunit');
+					$command = 'cd '.DOCROOT.'; '.$phpunit_command.' -c "'.$phpunit_config.'"';
 
 					// Respect the group options
 					\Cli::option('group') and $command .= ' --group '.\Cli::option('group');

--- a/config/oil.php
+++ b/config/oil.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ * 
+ * @package    Fuel
+ * @version    1.5
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2013 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+/**
+ * NOTICE:
+ * 
+ * If you need to make modifications to the default configuraion, copy
+ * this file to your app/config folder, and make them in there.
+ *
+ * This will allow you to upgrade fuel without losing your custom config.
+ */
+
+return array(
+	'phpunit' => array(
+		
+		/**
+		 * These phpunit settings allow oil to run your project's phpunit
+		 * tests. If you've installed phpunit as a global install via
+		 * pear, then the defaults don't need to be changed. But if you've
+		 * installed phpunit via some other method such as Composer,
+		 * you'll need to update these settings to reflect that.
+		 *
+		 * autoload_path - the path to PHPUnit's Autoload.php file.
+		 * binary_path - the full path you'd type into the command line
+		 *  to run phpunit from an arbitrary directory.
+		 *
+		 * For example, if you've installed phpunit via Composer, your
+		 * autoload_path will probably be something like:
+		 *     'autoload_path' => DOCROOT.'vendor/phpunit/phpunit/PHPUnit/Autoload.php',
+		 * and your binary path will probably be something like:
+		 *     'binary_path' => DOCROOT.'vendor/bin/phpunit',
+		 * 
+		 * At present, there is no support for phpunit.phar.
+		 */
+
+		'autoload_path' => 'PHPUnit/Autoload.php' ,
+		'binary_path' => 'phpunit' ,
+
+	),
+);
+


### PR DESCRIPTION
Now that PHPUnit allows you to install via multiple methods (such as composer), we can't assume it will always be in the path and that PHPUnit/Autoload.php will always be in PHP's include_path.

This change will keep the current behavior as the default but will allow you to configure the paths to both PHPUnit/Autoload.php and the phpunit executable.

Comments?
