### PR TITLE
Added unsigned to the id when using generate

### DIFF
--- a/classes/generate/migration/actions.php
+++ b/classes/generate/migration/actions.php
@@ -67,7 +67,7 @@ class Generate_Migration_Actions
 		}
 
 		// ID Field
-		$have_id or $field_str = "\t\t\t'id' => array('constraint' => 11, 'type' => 'int', 'auto_increment' => true),".PHP_EOL . $field_str;
+		$have_id or $field_str = "\t\t\t'id' => array('constraint' => 11, 'type' => 'int', 'auto_increment' => true, 'unsigned' => true),".PHP_EOL . $field_str;
 
 		$up = <<<UP
 		\DBUtil::create_table('{$subjects[1]}', array(


### PR DESCRIPTION
I always go in and give the ID `'unsigned' => true` whenever I use generate, wondered if other people do the same? Can’t think of a reason not to do it.
