### PR TITLE
Aid debugging and always exit indicating error on uncaught exception

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -207,13 +207,27 @@ class Command
 			}
 		}
 
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
-			\Cli::error('Error: '.$e->getMessage());
-			\Cli::beep();
-
-			\Cli::option('speak') and `say --voice="Trinoids" "{$e->getMessage()}"`;
+			static::print_exception($e);
 			exit(1);
+		}
+	}
+
+	public static function print_exception(\Exception $ex)
+	{
+		\Cli::error('Uncaught exception '.get_class($ex).': '.$ex->getMessage());
+		\Cli::error('Callstack: ');
+		\Cli::error($ex->getTraceAsString());
+		\Cli::beep();
+
+		\Cli::option('speak') and `say --voice="Trinoids" "{$ex->getMessage()}"`;
+
+		if (($previous = $ex->getPrevious()) != null)
+		{
+			\Cli::error('');
+			\Cli::error('Previous exception: ');
+			static::print_exception($previous);
 		}
 	}
 


### PR DESCRIPTION
Attached is some simple code that should fix the following issues:
- When running an oil command that generates an uncaught exception - catch it and exit with status code 1. Even if the exception does not extend from Oil\Exception.
- When exiting because of an exception. Print some more helpful exception details (type, message + stacktrace). Also recursively iterate through the previous exceptions and print their details as well.
