### PR TITLE
Fix 'Unable to read existing migrations' error on PHP 5.2.5 or later.

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -467,10 +467,17 @@ VIEW;
 		}
 
 		// Check if a migration with this name already exists
-		if (($duplicates = glob(APPPATH."migrations/*_{$migration_name}*")) === false)
-		{
-			throw new Exception("Unable to read existing migrations. Do you have an 'open_basedir' defined?");
-		}
+        if (sizeof(array_filter(scandir(APPPATH . "migrations/"), function ($var) { return (substr($var, 0, 1) !== '.'); })) > 0)
+        {
+            if (($duplicates = glob(APPPATH . "migrations/*_{$migration_name}*")) === false)
+            {
+                throw new Exception("Unable to read existing migrations. Do you have an 'open_basedir' defined?");
+            }
+        }
+        else
+        {
+            $duplicates = array();
+        }
 
 		if (count($duplicates) > 0)
 		{
@@ -947,13 +954,21 @@ HELP;
 
 	// Helper methods
 
-	private static function _find_migration_number()
-	{
-		$glob = glob(APPPATH .'migrations/*_*.php');
-		list($last) = explode('_', basename(end($glob)));
+    private static function _find_migration_number()
+    {
+        $glob = glob(APPPATH . 'migrations/*_*.php');
 
-		return str_pad($last + 1, 3, '0', STR_PAD_LEFT);
-	}
+        if ($glob === false)
+        {
+            return '001';
+        }
+        else
+        {
+            list($last) = explode('_', basename(end($glob)));
+
+            return str_pad($last + 1, 3, '0', STR_PAD_LEFT);
+        }
+    }
 
 	private static function _update_current_version($version)
 	{


### PR DESCRIPTION
scafold : Error: Unable to read existing migrations. Do you have an 'open_basedir' defined?
http://fuelphp.com/forums/discussion/10303/scafold-error-unable-to-read-existing-migrations-do-you-have-an-039open_basedir039-defined

glob() returns FALSE instead of an empty array since PHP 5.2.5 when wildcard is used in the argument and  the directory is empty.

Backward Incompatible Changes
http://www.php.net/manual/en/migration52.incompatible.php

Signed-off-by: Hideki Okamoto tox2ro@gmail.com
