### PR TITLE
Fix Generate::migration()

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -539,24 +539,24 @@ VIEW;
 				{
 					case 'create':
 						$subjects = array(false, $sentence);
-						break;
+					break;
 					case 'add':
 						$subjects = explode('.to.', $sentence);
-						break;
+					break;
 					case 'delete':
 						$subjects = explode('.from.', $sentence);
-						break;
+					break;
 					case 'rename_field':
 						$subjects = sscanf(str_replace('.', ' ', $sentence), '%s to %s in %s');
-						break;
+					break;
 					case 'rename_table':
 						$subjects = explode('.to.', $sentence);
-						break;
+					break;
 					case 'drop':
 						$subjects = array(false, $sentence);
-						break;
-					default:
-						break 2;
+					break;
+					default :
+					break 2;
 				}
 
 				$subjects = str_replace('.', '_', $subjects);


### PR DESCRIPTION
This fixes the root of https://github.com/fuel/oil/pull/177

Current magic migrations does not care of the case where the column name (or table name) contains underscores (or reserved words for example _to_, _from_ and _in_). 

In order to split the strict sense of the word, should not use underscores as concatenation character.
I propose the "." instead of  the "_".
But generating still allows "_" for compatibility.

The cases of current.

``` sh
php oil g migration delete_is_visible_from_articles is_visible:bool
# The code generated doesn't specify table name.

php oil g migration add_to_mail_to_contact_to_users to_mail:varchar[255]
# The code generated doesn't specify table name.
```

This change enables the followings.

``` sh
php oil g migration delete_is_visible_from_articles is_visible:bool
# The code generated is correct.

php oil g migration add.to_mail.to.contact_to_users to_mail:varchar[255]
# "." can be used to split the meaning
```
