### PR TITLE
oil test testrunner specified execution file

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -188,6 +188,7 @@ class Command
 					\Cli::option('coverage-clover') and $command .= ' --coverage-clover '.\Cli::option('coverage-clover');
 					\Cli::option('coverage-text') and $command .= ' --coverage-text='.\Cli::option('coverage-text');
 					\Cli::option('coverage-php') and $command .= ' --coverage-php '.\Cli::option('coverage-php');
+					\Cli::option('file') and $command .= ' '.\Cli::option('file');
 
 					\Cli::write('Tests Running...This may take a few moments.', 'green');
 


### PR DESCRIPTION
I'm sorry this is English meaning I did not have to translate the translation through google.

I want to be able to run in the specified file in the oil test of fuelPHP.
The path that you want to run unittest file = - Then at the command-line options
Why does it?

How to use

```
php oil t - file = / path / to / testfile
```
