### PR TITLE
support phpunit --log-junit option on 'oil test'

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -188,8 +188,8 @@ class Command
 					\Cli::option('coverage-clover') and $command .= ' --coverage-clover '.\Cli::option('coverage-clover');
 					\Cli::option('coverage-text') and $command .= ' --coverage-text='.\Cli::option('coverage-text');
 					\Cli::option('coverage-php') and $command .= ' --coverage-php '.\Cli::option('coverage-php');
-					\Cli::option('file') and $command .= ' '.\Cli::option('file');
 					\Cli::option('log-junit') and $command .= ' --log-junit '.\Cli::option('log-junit');
+					\Cli::option('file') and $command .= ' '.\Cli::option('file');
 
 					\Cli::write('Tests Running...This may take a few moments.', 'green');
 

--- a/classes/command.php
+++ b/classes/command.php
@@ -189,6 +189,7 @@ class Command
 					\Cli::option('coverage-text') and $command .= ' --coverage-text='.\Cli::option('coverage-text');
 					\Cli::option('coverage-php') and $command .= ' --coverage-php '.\Cli::option('coverage-php');
 					\Cli::option('file') and $command .= ' '.\Cli::option('file');
+					\Cli::option('log-junit') and $command .= ' --log-junit '.\Cli::option('log-junit');
 
 					\Cli::write('Tests Running...This may take a few moments.', 'green');
 


### PR DESCRIPTION
`oil test` be support `--log-junit` option.

http://www.phpunit.de/manual/3.7/en/textui.html
`--log-junit <file>        Log test execution in JUnit XML format to file.`

**Run example:**
`$ oil t --group=App --log-junit=build/testresult.xml`
