### PR TITLE
add use date number option to generate migration

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -1020,6 +1020,10 @@ HELP;
 
 	private static function _find_migration_number()
 	{
+		if(\Config::get('oil.generate.migration.number.use_date', false)){
+			return date('ymdHi');
+		}
+
 		$glob = glob(APPPATH .'migrations/*_*.php');
 		list($last) = explode('_', basename(end($glob)));
 

--- a/config/oil.php
+++ b/config/oil.php
@@ -48,5 +48,16 @@ return array(
 		'binary_path' => 'phpunit' ,
 
 	),
+	'generate' => array(
+		'migration' => array(
+			'number' => array(
+				/*
+				 * When true, migration number is date
+				 * ex)2013/04/05 12:34 -> 1304051234_create_bars.php
+				 */
+				'use_date' => false,
+			),
+		),
+	),
 );
 


### PR DESCRIPTION
- default
  - `$ oil g migration foo x:string`
  - generate `fuel/app/migrations/001_create_foo.php`
- when enable this option
  - `$ oil g migration foo x:string`
  - generate `fuel/app/migrations/1305111324_create_foo.php`
  - like a ruby on rails

Format is `ymdHi`, isn't `YmdHis`, because Migrate use 130511324 as a integer, on 32-bit system can't over `2147483648`.

Signed-off-by: takyam takayuki.yamaguch.m@gmail.com
