### PR TITLE
Removed "static" from task fn generation

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -848,7 +848,7 @@ MIGRATION;
 	 *
 	 * @return string
 	 */
-	public static function '.$action.'($args = NULL)
+	public function '.$action.'($args = NULL)
 	{
 		echo "\n===========================================";
 		echo "\nRunning task ['.\Inflector::humanize($name).':'. \Inflector::humanize($action) . ']";
@@ -877,7 +877,7 @@ MIGRATION;
 	 *
 	 * @return string
 	 */
-	public static function run($args = NULL)
+	public function run($args = NULL)
 	{
 		echo "\n===========================================";
 		echo "\nRunning DEFAULT task ['.\Inflector::humanize($name).':'. \Inflector::humanize($action) . ']";


### PR DESCRIPTION
Removed keyword `static` from oil's generation class.  Newly generated tasks will match the [documentation](http://fuelphp.com/docs/general/tasks.html). 

I ran into the issue where I had created an abstract class for my task to extend with parameters in the __construct - my ::run tried to instantiate `new static('a', 'b')` only to have oil error out.  

Because my oil generated static methods I didn't think oil would also instantiate the class. 
