### PR TITLE
Changed refine run to set args to array as default

### DIFF
--- a/classes/refine.php
+++ b/classes/refine.php
@@ -23,7 +23,7 @@ namespace Oil;
  */
 class Refine
 {
-	public static function run($task, $args)
+	public static function run($task, $args = array())
 	{
 		$task = strtolower($task);
 


### PR DESCRIPTION
Before you had to do:
`\Oil\Refine::run('install', array());`

After you can now do:
`\Oil\Refine::run('install');`

If the task doesn't have required arguments then we shouldn't need to pass an empty `array()`.
