### PR TITLE
Package generation added

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -64,6 +64,7 @@ class Command
 						case 'model':
 						case 'migration':
 						case 'task':
+						case 'package':
 							call_user_func('Oil\Generate::'.$action, array_slice($args, 3));
 						break;
 

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -976,12 +976,12 @@ HELP;
 			throw new \Exception('No package name has been provided.');
 		}
 
-		if ( ! in_array($path, \Config::get('package_paths')) && ! in_array(realpath($path), \Config::get('package_paths')) )
+		if ( ! in_array($path, \Config::get('package_paths')) and ! in_array(realpath($path), \Config::get('package_paths')) )
 		{
 			throw new \Exception('Given path is not a valid package path.');
 		}
 
-		! \Str::ends_with($path, DS) && $path .= DS;
+		\Str::ends_with($path, DS) or $path .= DS;
 		$path .= $name . DS;
 
 		if (is_dir($path))
@@ -1028,7 +1028,7 @@ README;
 
 		if ( ! empty($drivers))
 		{
-			! ($drivers === true) and $drivers = explode(',', $drivers);
+			$drivers === true or $drivers = explode(',', $drivers);
 
 			$output = <<<CLASS
 <?php

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -1085,7 +1085,7 @@ class {$class_name}
 
 		\$driver = new \$class(\$config);
 
-		static::\$_instances[\$instance] =& \$driver;
+		static::\$_instances[\$instance] = \$driver;
 
 		return \$driver;
 	}

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -967,7 +967,7 @@ HELP;
 	{
 		$name       = str_replace(array('/', '_', '-'), '', \Str::lower(array_shift($args)));
 		$class_name = ucfirst($name);
-		$composer   = \Cli::option('composer', \Cli::option('c', false));
+		$vsc        = \Cli::option('vsc', \Cli::option('v', false));
 		$path       = \Cli::option('path', \Cli::option('p', PKGPATH));
 		$drivers    = \Cli::option('drivers', \Cli::option('d', ''));
 
@@ -989,7 +989,7 @@ HELP;
 			throw new \Exception('Package already exists.');
 		}
 
-		if ($composer)
+		if ($vsc)
 		{
 			$output = <<<COMPOSER
 {
@@ -1016,15 +1016,15 @@ HELP;
 COMPOSER;
 
 			static::create($path . 'composer.json', $output);
-		}
 
-		$output = <<<README
+			$output = <<<README
 # {$class_name} package
 Here comes some description
 
 README;
 
-		static::create($path . 'README.md', $output);
+			static::create($path . 'README.md', $output);
+		}
 
 		if ( ! empty($drivers))
 		{

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -967,7 +967,7 @@ HELP;
 	{
 		$name       = str_replace(array('/', '_', '-'), '', \Str::lower(array_shift($args)));
 		$class_name = ucfirst($name);
-		$vsc        = \Cli::option('vsc', \Cli::option('v', false));
+		$vcs        = \Cli::option('vcs', \Cli::option('v', false));
 		$path       = \Cli::option('path', \Cli::option('p', PKGPATH));
 		$drivers    = \Cli::option('drivers', \Cli::option('d', ''));
 
@@ -989,7 +989,7 @@ HELP;
 			throw new \Exception('Package already exists.');
 		}
 
-		if ($vsc)
+		if ($vcs)
 		{
 			$output = <<<COMPOSER
 {

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -963,6 +963,363 @@ HELP;
 	}
 
 
+	public static function package($args, $build = true)
+	{
+		$name       = str_replace(array('/', '_', '-'), '', \Str::lower(array_shift($args)));
+		$class_name = ucfirst($name);
+		$composer   = \Cli::option('composer', \Cli::option('c', false));
+		$path       = \Cli::option('path', \Cli::option('p', PKGPATH));
+		$drivers    = \Cli::option('drivers', \Cli::option('d', ''));
+
+		if (empty($name))
+		{
+			throw new \Exception('No package name has been provided.');
+		}
+
+		if ( ! in_array($path, \Config::get('package_paths')) && ! in_array(realpath($path), \Config::get('package_paths')) )
+		{
+			throw new \Exception('Given path is not a valid package path.');
+		}
+
+		! \Str::ends_with($path, DS) && $path .= DS;
+		$path .= $name . DS;
+
+		if (is_dir($path))
+		{
+			throw new \Exception('Package already exists.');
+		}
+
+		if ($composer)
+		{
+			$output = <<<COMPOSER
+{
+	"name": "fuel/{$name}",
+	"type": "fuel-package",
+	"description": "{$class_name} package",
+	"keywords": [""],
+	"homepage": "http://fuelphp.com",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "AUTHOR",
+			"email": "AUTHOR@example.com"
+		}
+	],
+	"require": {
+		"composer/installers": "~1.0"
+	},
+	"extra": {
+		"installer-name": "{$name}"
+	}
+}
+
+COMPOSER;
+
+			static::create($path . 'composer.json', $output);
+		}
+
+		$output = <<<README
+# {$class_name} package
+Here comes some description
+
+README;
+
+		static::create($path . 'README.md', $output);
+
+		if ( ! empty($drivers))
+		{
+			! ($drivers === true) && $drivers = explode(',', $drivers);
+
+			$output = <<<CLASS
+<?php
+
+namespace {$class_name};
+
+class {$class_name}Exception extends \FuelException {}
+
+class {$class_name}
+{
+	/**
+	 * loaded instance
+	 */
+	protected static \$_instance = null;
+
+	/**
+	 * array of loaded instances
+	 */
+	protected static \$_instances = array();
+
+	/**
+	 * Default config
+	 * @var array
+	 */
+	protected static \$_defaults = array();
+
+	/**
+	 * Init
+	 */
+	public static function _init()
+	{
+		\Config::load('{$name}', true);
+	}
+
+	/**
+	 * {$class_name} driver forge.
+	 *
+	 * @param	string			\$instance		Instance name
+	 * @param	array			\$config		Extra config array
+	 * @return  {$class_name} instance
+	 */
+	public static function forge(\$instance = 'default', \$config = array())
+	{
+		! is_array(\$config) && \$config = array('driver' => \$config);
+
+		\$config = \Arr::merge(static::\$_defaults, \Config::get('{$name}', array()), \$config);
+
+		\$class = '\\{$class_name}\\{$class_name}_' . ucfirst(strtolower(\$config['driver']));
+
+		if( ! class_exists(\$class, true))
+		{
+			throw new \FuelException('Could not find {$class_name} driver: ' . ucfirst(strtolower(\$config['driver']));
+		}
+
+		\$driver = new \$class(\$config);
+
+		static::\$_instances[\$instance] =& \$driver;
+
+		return \$driver;
+	}
+
+	/**
+	 * Return a specific driver, or the default instance (is created if necessary)
+	 *
+	 * @param   string  \$instance
+	 * @return  {$class_name} instance
+	 */
+	public static function instance(\$instance = null)
+	{
+		if (\$instance !== null)
+		{
+			if ( ! array_key_exists(\$instance, static::\$_instances))
+			{
+				return false;
+			}
+
+			return static::\$_instances[\$instance];
+		}
+
+		if (static::\$_instance === null)
+		{
+			static::\$_instance = static::forge();
+		}
+
+		return static::\$_instance;
+	}
+}
+
+CLASS;
+
+			static::create($path . 'classes' . DS . $name . '.php', $output);
+
+
+			$output = <<<DRIVER
+<?php
+
+namespace {$class_name};
+
+abstract class {$class_name}_Driver
+{
+	/**
+	* Driver config
+	* @var array
+	*/
+	protected \$config = array();
+
+	/**
+	* Driver constructor
+	*
+	* @param array \$config driver config
+	*/
+	public function __construct(array \$config = array())
+	{
+		\$this->config = \$config;
+	}
+
+	/**
+	* Get a driver config setting.
+	*
+	* @param string \$key the config key
+	* @param mixed  \$default the default value
+	* @return mixed the config setting value
+	*/
+	public function get_config(\$key, \$default = null)
+	{
+		return \Arr::get(\$this->config, \$key, \$default);
+	}
+
+	/**
+	* Set a driver config setting.
+	*
+	* @param string \$key the config key
+	* @param mixed \$value the new config value
+	* @return object \$this for chaining
+	*/
+	public function set_config(\$key, \$value)
+	{
+		\Arr::set(\$this->config, \$key, \$value);
+
+		return \$this;
+	}
+}
+
+DRIVER;
+
+			static::create($path . 'classes' . DS . $name . DS . 'driver.php', $output);
+
+			$bootstrap =  "\n\t'{$class_name}\\\\{$class_name}_Driver' => __DIR__ . '/classes/{$name}/driver.php',";
+			if (is_array($drivers))
+			{
+				foreach ($drivers as $driver)
+				{
+					$driver = \Str::lower($driver);
+					$driver_name = ucfirst($driver);
+					$output = <<<CLASS
+<?php
+
+namespace {$class_name};
+
+class {$class_name}_{$driver_name}  extends {$class_name}_Driver
+{
+	/**
+	* Driver specific functions
+	*/
+}
+
+CLASS;
+					$bootstrap .= "\n\t'{$class_name}\\\\{$class_name}_{$driver_name}' => __DIR__ . '/classes/{$name}/{$driver}.php',";
+					static::create($path . 'classes' . DS . $name . DS . $driver . '.php', $output);
+				}
+			}
+		}
+		else
+		{
+			$output = <<<CLASS
+<?php
+
+namespace {$class_name};
+
+class {$class_name}Exception extends \FuelException {}
+
+class {$class_name}
+{
+	/**
+	 * Default config
+	 * @var array
+	 */
+	protected static \$_defaults = array();
+
+	/**
+	* Driver config
+	* @var array
+	*/
+	protected \$config = array();
+
+	/**
+	 * Init
+	 */
+	public static function _init()
+	{
+		\Config::load('{$name}', true);
+	}
+
+	/**
+	 * {$class_name} driver forge.
+	 *
+	 * @param	array			\$config		Config array
+	 * @return  {$class_name}
+	 */
+	public static function forge(\$config = array())
+	{
+		\$config = \Arr::merge(static::\$_defaults, \Config::get('{$name}', array()), \$config);
+
+		\$class = new static(\$config);
+
+		return \$class;
+	}
+
+	/**
+	* Driver constructor
+	*
+	* @param array \$config driver config
+	*/
+	public function __construct(array \$config = array())
+	{
+		\$this->config = \$config;
+	}
+
+	/**
+	* Get a config setting.
+	*
+	* @param string \$key the config key
+	* @param mixed  \$default the default value
+	* @return mixed the config setting value
+	*/
+	public function get_config(\$key, \$default = null)
+	{
+		return \Arr::get(\$this->config, \$key, \$default);
+	}
+
+	/**
+	* Set a config setting.
+	*
+	* @param string \$key the config key
+	* @param mixed \$value the new config value
+	* @return object \$this for chaining
+	*/
+	public function set_config(\$key, \$value)
+	{
+		\Arr::set(\$this->config, \$key, \$value);
+
+		return \$this;
+	}
+}
+
+CLASS;
+
+			static::create($path . 'classes' . DS . $name . '.php', $output);
+
+			$bootstrap = "";
+		}
+
+			$output = <<<CONFIG
+<?php
+
+return array(
+
+);
+
+CONFIG;
+
+			static::create($path . 'config' . DS . $name . '.php', $output);
+
+		$output = <<<CLASS
+<?php
+
+Autoloader::add_core_namespace('{$class_name}');
+
+Autoloader::add_classes(array(
+	'{$class_name}\\\\{$class_name}' => __DIR__ . '/classes/{$name}.php',
+	'{$class_name}\\\\{$class_name}Exception' => __DIR__ . '/classes/{$name}.php',
+{$bootstrap}
+));
+
+CLASS;
+		static::create($path . 'bootstrap.php', $output);
+
+		$build and static::build();
+	}
+
+
 	public static function create($filepath, $contents, $type = 'file')
 	{
 		$directory = dirname($filepath);

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -1072,7 +1072,7 @@ class {$class_name}
 	 */
 	public static function forge(\$instance = 'default', \$config = array())
 	{
-		! is_array(\$config) and \$config = array('driver' => \$config);
+		is_array(\$config) or \$config = array('driver' => \$config);
 
 		\$config = \Arr::merge(static::\$_defaults, \Config::get('{$name}', array()), \$config);
 

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -1028,7 +1028,7 @@ README;
 
 		if ( ! empty($drivers))
 		{
-			! ($drivers === true) && $drivers = explode(',', $drivers);
+			! ($drivers === true) and $drivers = explode(',', $drivers);
 
 			$output = <<<CLASS
 <?php
@@ -1072,7 +1072,7 @@ class {$class_name}
 	 */
 	public static function forge(\$instance = 'default', \$config = array())
 	{
-		! is_array(\$config) && \$config = array('driver' => \$config);
+		! is_array(\$config) and \$config = array('driver' => \$config);
 
 		\$config = \Arr::merge(static::\$_defaults, \Config::get('{$name}', array()), \$config);
 


### PR DESCRIPTION
I added package generation to oil.

Usage:
use --vsc or -v to create composer.json and README.md
use --path or -p to add your custom path (MUST be included in package_paths)
use --drivers or -d to create a driver-based package
use --drivers/-d=driver1,driver2 to create default drivers
