### PR TITLE
rename css class "alert-error" to "alert-danger"

### DIFF
--- a/views/admin/template.php
+++ b/views/admin/template.php
@@ -75,7 +75,7 @@
 				</div>
 <?php endif; ?>
 <?php if (Session::get_flash('error')): ?>
-				<div class="alert alert-error alert-dismissable">
+				<div class="alert alert-danger alert-dismissable">
 					<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
 					<p>
 					<?php echo implode('</p><p>', (array) Session::get_flash('error')); ?>

--- a/views/scaffolding/template.php
+++ b/views/scaffolding/template.php
@@ -22,7 +22,7 @@
 			</div>
 <?php endif; ?>
 <?php if (Session::get_flash('error')): ?>
-			<div class="alert alert-error">
+			<div class="alert alert-danger">
 				<strong>Error</strong>
 				<p>
 				<?php echo implode('</p><p>', e((array) Session::get_flash('error'))); ?>


### PR DESCRIPTION
the former was deprecated in Bootstrap 3, [which Fuel already includes](https://github.com/fuel/fuel/blob/1.7/master/public/assets/css/bootstrap.css).
