### PR TITLE
Fix coding style of generated controllers by scaffold/admin

### DIFF
--- a/views/admin/crud/controller.php
+++ b/views/admin/crud/controller.php
@@ -1,12 +1,12 @@
 <?php echo '<?php' ?>
 
-class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent).PHP_EOL; ?>
+class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent)."\n"; ?>
 {
 
 <?php foreach ($actions as $action): ?>
 	public function action_<?php echo $action['name']; ?>(<?php echo $action['params']; ?>)
 	{
-<?php echo $action['code'].PHP_EOL; ?>
+<?php echo $action['code']."\n"; ?>
 	}
 
 <?php endforeach; ?>

--- a/views/admin/crud/controller.php
+++ b/views/admin/crud/controller.php
@@ -1,6 +1,6 @@
 <?php echo '<?php' ?>
 
-class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent) ?> 
+class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent).PHP_EOL; ?>
 {
 
 <?php foreach ($actions as $action): ?>
@@ -10,5 +10,4 @@ class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option
 	}
 
 <?php endforeach; ?>
-
 }

--- a/views/admin/crud/controllers/base.php
+++ b/views/admin/crud/controllers/base.php
@@ -1,6 +1,7 @@
 <?php
 
-class Controller_Base extends Controller_Template {
+class Controller_Base extends Controller_Template
+{
 
 	public function before()
 	{

--- a/views/admin/orm/controller.php
+++ b/views/admin/orm/controller.php
@@ -1,6 +1,6 @@
 <?php echo '<?php' ?>
 
-class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent) ?>
+class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent).PHP_EOL; ?>
 {
 
 <?php foreach ($actions as $action): ?>
@@ -10,5 +10,4 @@ class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option
 	}
 
 <?php endforeach; ?>
-
 }

--- a/views/admin/orm/controller.php
+++ b/views/admin/orm/controller.php
@@ -1,12 +1,12 @@
 <?php echo '<?php' ?>
 
-class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent).PHP_EOL; ?>
+class Controller_<?php echo $controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent)."\n"; ?>
 {
 
 <?php foreach ($actions as $action): ?>
 	public function action_<?php echo $action['name']; ?>(<?php echo $action['params']; ?>)
 	{
-<?php echo $action['code'].PHP_EOL; ?>
+<?php echo $action['code']."\n"; ?>
 	}
 
 <?php endforeach; ?>

--- a/views/admin/orm/controllers/base.php
+++ b/views/admin/orm/controllers/base.php
@@ -1,6 +1,7 @@
 <?php
 
-class Controller_Base extends Controller_Template {
+class Controller_Base extends Controller_Template
+{
 
 	public function before()
 	{

--- a/views/scaffolding/crud/controller.php
+++ b/views/scaffolding/crud/controller.php
@@ -1,12 +1,12 @@
 <?php echo '<?php' ?>
 
-class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent).PHP_EOL; ?>
+class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent)."\n"; ?>
 {
 
 <?php foreach ($actions as $action): ?>
 	public function action_<?php echo $action['name']; ?>(<?php echo $action['params']; ?>)
 	{
-<?php echo $action['code'].PHP_EOL; ?>
+<?php echo $action['code']."\n"; ?>
 	}
 
 <?php endforeach; ?>

--- a/views/scaffolding/crud/controller.php
+++ b/views/scaffolding/crud/controller.php
@@ -1,6 +1,6 @@
 <?php echo '<?php' ?>
 
-class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent) ?>
+class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent).PHP_EOL; ?>
 {
 
 <?php foreach ($actions as $action): ?>
@@ -10,5 +10,4 @@ class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_na
 	}
 
 <?php endforeach; ?>
-
 }

--- a/views/scaffolding/orm/controller.php
+++ b/views/scaffolding/orm/controller.php
@@ -1,12 +1,12 @@
 <?php echo '<?php' ?>
 
-class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent).PHP_EOL; ?>
+class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent)."\n"; ?>
 {
 
 <?php foreach ($actions as $action): ?>
 	public function action_<?php echo $action['name']; ?>(<?php echo $action['params']; ?>)
 	{
-<?php echo $action['code'].PHP_EOL; ?>
+<?php echo $action['code']."\n"; ?>
 	}
 
 <?php endforeach; ?>

--- a/views/scaffolding/orm/controller.php
+++ b/views/scaffolding/orm/controller.php
@@ -1,6 +1,6 @@
 <?php echo '<?php' ?>
 
-class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent) ?>
+class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_name; ?> extends <?php echo \Cli::option('extends', $controller_parent).PHP_EOL; ?>
 {
 
 <?php foreach ($actions as $action): ?>
@@ -10,5 +10,4 @@ class <?php echo \Config::get('controller_prefix', 'Controller_').$controller_na
 	}
 
 <?php endforeach; ?>
-
 }


### PR DESCRIPTION
 Current output:

```
class Controller_Admin_Form extends Controller_Admin{
```

Fixed:

```
class Controller_Admin_Form extends Controller_Admin
{
```
