### PR TITLE
Small fix in the arguments list

### DIFF
--- a/tasks/fromdb.php
+++ b/tasks/fromdb.php
@@ -236,7 +236,7 @@ HELP;
 		}
 
 		// construct the arguments list, starting with the table name
-		$arguments = array($table);
+		$arguments = array(\Inflector::singularize($table));
 
 		// set some switches
 		$include_timestamps = false;


### PR DESCRIPTION
Right now, if we have an **items** table and we execute fromdb on this table, it will generate those files:

```
Creating migration: APPPATH/migrations/001_create_items.php
Creating model: APPPATH/classes/model/item.php
Creating controller: APPPATH/classes/controller/items.php
Creating view: APPPATH/views/items/index.php
Creating view: APPPATH/views/items/view.php
Creating view: APPPATH/views/items/create.php
Creating view: APPPATH/views/items/edit.php
Creating view: APPPATH/views/items/_form.php
Creating view: APPPATH/views/template.php
```

The problem is that when we normally generate those files from a regular scaffold, the location are a little different:
- APPPATH/views/items -> APPPATH/views/item
- APPPATH/classes/controller/items.php -> APPPATH/classes/controller/item.php

This pull request tries to fix that, let me know your views on this.

Thanks,
