### PR TITLE
Replace docs base URL `docs.fuelphp.com` with `fuelphp.com/docs`.

### DIFF
--- a/classes/cell.php
+++ b/classes/cell.php
@@ -180,7 +180,7 @@ Examples:
   oil cell uninstall <cell-name>
 
 Documentation:
-  http://docs.fuelphp.com/packages/oil/cell.html
+  http://fuelphp.com/docs/packages/oil/cell.html
 HELP;
 		\Cli::write($output);
 

--- a/classes/command.php
+++ b/classes/command.php
@@ -236,7 +236,7 @@ HELP;
 						// Respect the group options
 						\Cli::option('group') and $command .= ' --group '.\Cli::option('group');
 						\Cli::option('exclude-group') and $command .= ' --exclude-group '.\Cli::option('exclude-group');
-						
+
 						// Respect the testsuite options
 						\Cli::option('testsuite') and $command .= ' --testsuite '.\Cli::option('testsuite');
 
@@ -376,7 +376,7 @@ More information:
   about that specific command: php oil package help
 
 Documentation:
-  http://docs.fuelphp.com/packages/oil/intro.html
+  http://fuelphp.com/docs/packages/oil/intro.html
 
 HELP;
 

--- a/classes/generate.php
+++ b/classes/generate.php
@@ -1302,7 +1302,7 @@ Note that the next two lines are equivalent:
   php oil g scaffold/orm <modelname> ...
 
 Documentation:
-  http://docs.fuelphp.com/packages/oil/generate.html
+  http://fuelphp.com/docs/packages/oil/generate.html
 HELP;
 
 		\Cli::write($output);

--- a/classes/refine.php
+++ b/classes/refine.php
@@ -167,7 +167,7 @@ Description:
 Available tasks:
 $output_available_tasks
 Documentation:
-    http://docs.fuelphp.com/packages/oil/refine.html
+    http://fuelphp.com/docs/packages/oil/refine.html
 HELP;
 		\Cli::write($output);
 

--- a/views/admin/dashboard.php
+++ b/views/admin/dashboard.php
@@ -19,7 +19,7 @@
 		<h2>Contribute</h2>
 		<p>FuelPHP wouldn't exist without awesome contributions from the community.  Use the links below to get contributing.</p>
 		<ul>
-			<li><a href="http://docs.fuelphp.com/general/coding_standards.html">Coding Standards</a></li>
+			<li><a href="http://fuelphp.com/docs/general/coding_standards.html">Coding Standards</a></li>
 			<li><a href="http://github.com/fuel/fuel">GitHub Respository</a></li>
 			<li><a href="http://fuelphp.com/contribute/issue-tracker">Issue Tracker</a></li>
 		</ul>


### PR DESCRIPTION
Hi. I minor tweaked to replace docs base URL `docs.fuelphp.com` with `fuelphp.com/docs` just because sometimes they were a little mixed. Thanks!
