### PR TITLE
generate: Add --with-test option to create test scaffolding

### DIFF
--- a/classes/generate.php
+++ b/classes/generate.php
@@ -161,6 +161,12 @@ CONF;
 		// Uppercase each part of the class name and remove hyphens
 		$class_name = \Inflector::classify(str_replace(array('\\', '/'), '_', $name), false);
 
+		// Generate with test?
+		$with_test = \Cli::option('with-test');
+		if ($with_test) {
+			static::_create_test('Controller', $class_name, $base_path);
+		}
+
 		// Stick "blog" to the start of the array
 		array_unshift($args, $filename);
 
@@ -282,6 +288,12 @@ PRESENTER;
 		$properties = "\n\t\t" . $properties . ",";
 
 		$contents = '';
+
+		// Generate with test?
+		$with_test = \Cli::option('with-test');
+		if ($with_test) {
+			static::_create_test('Model', $class_name, $base_path);
+		}
 
 		if (\Cli::option('crud'))
 		{
@@ -831,6 +843,12 @@ MODEL;
 </ul>
 <p>{$view_title}</p>
 VIEW;
+
+			// Generate with test?
+ 			$with_test = \Cli::option('with-test');
+            		if ($with_test) {
+               			static::_create_test('View', $controller, $base_path, $nav_item);
+			}
 
 			// Create this view
 			static::create($view_dir.$action.'.php', $view, 'view');
@@ -1785,6 +1803,25 @@ CLASS;
 		$contents = preg_replace("#('version'[ \t]+=>)[ \t]+([0-9]+),#i", "$1 $version,", $contents);
 
 		static::create($app_path, $contents, 'config');
+	}
+
+	private static function _create_test($type, $class_name, $base_path, $nav_item = '')
+	{
+		$filepath = $base_path.strtolower('tests'.DS.$type.DS.ucwords($class_name));
+		if ( ! empty($nav_item) and $type === 'View')
+		{
+			$filepath = $filepath.DS.strtolower($nav_item);
+			$class_name = $class_name.'_'.ucwords($nav_item);
+		}
+		$output = <<<TEST
+<?php
+
+class Test_{$type}_{$class_name} extends TestCase
+{
+}
+TEST;
+
+		static::create($filepath.'.php', $output, 'test');
 	}
 }
 


### PR DESCRIPTION
Add `--with-test` option to generate its test code scaffolding when run oil generate something.
See also: https://github.com/fuel/oil/issues/242.
