### PR TITLE
Pagination is rendered to string when generated from oil generate admin command

### DIFF
--- a/views/admin/orm/actions/index.php
+++ b/views/admin/orm/actions/index.php
@@ -9,7 +9,7 @@
 			->rows_limit($pagination->per_page)
 			->get();
 
-		$this->template->set_global('pagination', $pagination, true);
+		$this->template->set_global('pagination', $pagination, false);
 
 		$this->template->title   = "<?php echo ucfirst($plural_name); ?>";
 		$this->template->content = View::forge('<?php echo $view_path; ?>/index', $data);


### PR DESCRIPTION
## Process

1. Try to generate an admin page using `oil generate admin` command
2. Go to the page you have created, and try to create more than 10 data

## Current and expected result

Current result is the pagination is rendered as string instead of HTML

## Screenshot

Current result:

<img width="1387" alt="jepretan layar 2018-12-14 pukul 9 20 37 am" src="https://user-images.githubusercontent.com/3760093/49979874-97f4c680-ff83-11e8-9015-b81bd892b452.png">

Expected result:

<img width="1387" alt="jepretan layar 2018-12-14 pukul 9 38 09 am" src="https://user-images.githubusercontent.com/3760093/49980022-3da83580-ff84-11e8-8c31-bd699a23bf96.png">
