### PR TITLE
Update jQuery to 1.12.4 to satisfy Bootstrap requirements

### DIFF
--- a/views/admin/template.php
+++ b/views/admin/template.php
@@ -8,7 +8,7 @@
 		body { margin: 50px; }
 	</style>
 	<?php echo Asset::js(array(
-		'http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js',
+		'http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js',
 		'bootstrap.js',
 	)); ?>
 	<script>


### PR DESCRIPTION
## Summary

After updating to Bootstrap 3.3.7 (see [pull request I made](https://github.com/fuel/fuel/pull/318) for fuel repository), I cannot do any interaction such as clicking dropdown, etc. Turns out the problem was the Bootstrap 3.3.7 requires jQuery higher than 1.7.

It was my fault that I forgot that I've made some changes in template file (including upgrading jQuery to version 1.12.4), but I said that I haven't found any issues after updating to 3.3.7 confidently 🙇🏻‍♂️

## Process

1. Generate an admin page using `oil generate admin` command
2. Open the page, and try to inspect the page

## Current and expected result

The user cannot do any interactions such as hamburger button not showing menu navigation, etc.

## Screenshot

<img width="1387" alt="jepretan layar 2018-12-14 pukul 9 42 21 am" src="https://user-images.githubusercontent.com/3760093/49981686-a5ae4a00-ff8b-11e8-93ab-45a4dee70132.png">

