### PR TITLE
Beautify admin scaffold

### DIFF
--- a/views/admin/orm/views/actions/_form.php
+++ b/views/admin/orm/views/actions/_form.php
@@ -1,40 +1,38 @@
-<?php echo '<?php echo Form::open(); ?>' ?>
-
-
+<?php echo '<?php echo Form::open(); ?>'.PHP_EOL; ?>
 	<fieldset>
 <?php foreach ($fields as $field): ?>
 		<div class="form-group">
-			<?php echo "<?php echo Form::label('". \Inflector::humanize($field['name']) ."', '{$field['name']}', array('class'=>'control-label')); ?>\n"; ?>
+			<?php echo "<?php echo Form::label('". \Inflector::humanize($field['name']) ."', '{$field['name']}', array('class' => 'control-label')); ?>\n"; ?>
 
 <?php switch($field['type']):
+	case 'text':
+		echo "\t\t\t<?php echo Form::textarea('{$field['name']}', Input::post('{$field['name']}', isset(\${$singular_name}) ? \${$singular_name}->{$field['name']} : ''), array('class' => 'form-control', 'rows' => 8, 'placeholder' => '".\Inflector::humanize($field['name'])."')); ?>\n";
+	break;
 
-				case 'text':
-					echo "\t\t\t\t<?php echo Form::textarea('{$field['name']}', Input::post('{$field['name']}', isset(\${$singular_name}) ? \${$singular_name}->{$field['name']} : ''), array('class' => 'form-control', 'rows' => 8, 'placeholder'=>'".\Inflector::humanize($field['name'])."')); ?>\n";
-				break;
-
-				default:
-					echo "\t\t\t\t<?php echo Form::input('{$field['name']}', Input::post('{$field['name']}', isset(\${$singular_name}) ? \${$singular_name}->{$field['name']} : ''), array('class' => 'form-control', 'placeholder'=>'".\Inflector::humanize($field['name'])."')); ?>\n";
-
+	default:
+		echo "\t\t\t<?php echo Form::input('{$field['name']}', Input::post('{$field['name']}', isset(\${$singular_name}) ? \${$singular_name}->{$field['name']} : ''), array('class' => 'form-control', 'placeholder' => '".\Inflector::humanize($field['name'])."')); ?>\n";
 endswitch; ?>
-
 		</div>
+
 <?php endforeach; ?>
 		<div class="form-group">
-			<?php echo '<?php'; ?> echo Form::submit('submit', 'Save', array('class' => 'btn btn-primary')); <?php echo '?>'; ?>
+			<?php echo '<?php'; ?> echo Form::submit('submit', 'Save', array('class' => 'btn btn-primary')); <?php echo '?>'.PHP_EOL; ?>
 
 			<div class="pull-right">
-				<?php echo '<?php'; ?> if (Uri::segment(3) === 'edit'): <?php echo '?>'; ?>
+				<?php echo '<?php'; ?> if (Uri::segment(3) === 'edit'): <?php echo '?>'.PHP_EOL; ?>
 					<div class="btn-group">
-						<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$<?php echo $singular_name; ?>->id, 'View', array('class' => 'btn btn-info')); <?php echo '?>'; ?>
-						<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>', 'Back', array('class' => 'btn btn-default')); <?php echo '?>'; ?>
+						<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$<?php echo $singular_name; ?>->id, 'View', array('class' => 'btn btn-info')); <?php echo '?>'.PHP_EOL; ?>
+						<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>', 'Back', array('class' => 'btn btn-default')); <?php echo '?>'.PHP_EOL; ?>
 					</div>
-				<?php echo '<?php'; ?> else: <?php echo '?>'; ?>
-					<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>', 'Back', array('class' => 'btn btn-link')); <?php echo '?>'; ?>
-				<?php echo '<?php'; ?> endif <?php echo '?>'; ?>
+				<?php echo '<?php'; ?> else: <?php echo '?>'.PHP_EOL; ?>
+					<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>', 'Back', array('class' => 'btn btn-link')); <?php echo '?>'.PHP_EOL; ?>
+				<?php echo '<?php'; ?> endif <?php echo '?>'.PHP_EOL; ?>
 			</div>
 		</div>
 	</fieldset>
+
 <?php if ($csrf): ?>
 	<?php echo '<?php'; ?> echo Form::hidden(Config::get('security.csrf_token_key'), Security::fetch_token()); <?php echo '?>'; ?>
 <?php endif; ?>
+
 <?php echo '<?php'; ?> echo Form::close(); <?php echo '?>'; ?>

--- a/views/admin/orm/views/actions/_form.php
+++ b/views/admin/orm/views/actions/_form.php
@@ -1,4 +1,4 @@
-<?php echo '<?php echo Form::open(array("class"=>"form-horizontal")); ?>' ?>
+<?php echo '<?php echo Form::open(); ?>' ?>
 
 
 	<fieldset>
@@ -9,18 +9,17 @@
 <?php switch($field['type']):
 
 				case 'text':
-					echo "\t\t\t\t<?php echo Form::textarea('{$field['name']}', Input::post('{$field['name']}', isset(\${$singular_name}) ? \${$singular_name}->{$field['name']} : ''), array('class' => 'col-md-8 form-control', 'rows' => 8, 'placeholder'=>'".\Inflector::humanize($field['name'])."')); ?>\n";
+					echo "\t\t\t\t<?php echo Form::textarea('{$field['name']}', Input::post('{$field['name']}', isset(\${$singular_name}) ? \${$singular_name}->{$field['name']} : ''), array('class' => 'form-control', 'rows' => 8, 'placeholder'=>'".\Inflector::humanize($field['name'])."')); ?>\n";
 				break;
 
 				default:
-					echo "\t\t\t\t<?php echo Form::input('{$field['name']}', Input::post('{$field['name']}', isset(\${$singular_name}) ? \${$singular_name}->{$field['name']} : ''), array('class' => 'col-md-4 form-control', 'placeholder'=>'".\Inflector::humanize($field['name'])."')); ?>\n";
+					echo "\t\t\t\t<?php echo Form::input('{$field['name']}', Input::post('{$field['name']}', isset(\${$singular_name}) ? \${$singular_name}->{$field['name']} : ''), array('class' => 'form-control', 'placeholder'=>'".\Inflector::humanize($field['name'])."')); ?>\n";
 
 endswitch; ?>
 
 		</div>
 <?php endforeach; ?>
 		<div class="form-group">
-			<label class='control-label'>&nbsp;</label>
 			<?php echo '<?php'; ?> echo Form::submit('submit', 'Save', array('class' => 'btn btn-primary')); <?php echo '?>'; ?>
 		</div>
 	</fieldset>

--- a/views/admin/orm/views/actions/_form.php
+++ b/views/admin/orm/views/actions/_form.php
@@ -21,6 +21,17 @@ endswitch; ?>
 <?php endforeach; ?>
 		<div class="form-group">
 			<?php echo '<?php'; ?> echo Form::submit('submit', 'Save', array('class' => 'btn btn-primary')); <?php echo '?>'; ?>
+
+			<div class="pull-right">
+				<?php echo '<?php'; ?> if (Uri::segment(3) === 'edit'): <?php echo '?>'; ?>
+					<div class="btn-group">
+						<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$<?php echo $singular_name; ?>->id, 'View', array('class' => 'btn btn-info')); <?php echo '?>'; ?>
+						<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>', 'Back', array('class' => 'btn btn-default')); <?php echo '?>'; ?>
+					</div>
+				<?php echo '<?php'; ?> else: <?php echo '?>'; ?>
+					<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>', 'Back', array('class' => 'btn btn-link')); <?php echo '?>'; ?>
+				<?php echo '<?php'; ?> endif <?php echo '?>'; ?>
+			</div>
 		</div>
 	</fieldset>
 <?php if ($csrf): ?>

--- a/views/admin/orm/views/actions/create.php
+++ b/views/admin/orm/views/actions/create.php
@@ -1,7 +1,10 @@
 <h2>New <?php echo \Str::ucfirst($singular_name); ?></h2>
 <br>
 
-<?php echo '<?php'; ?> echo render('<?php echo $view_path; ?>/_form'); ?>
-
+<div class="row">
+	<div class="col-md-6">
+		<?php echo '<?php'; ?> echo render('<?php echo $view_path; ?>/_form'); ?>
+	</div>
+</div>
 
 <p><?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri ?>', 'Back'); <?php echo '?>'; ?></p>

--- a/views/admin/orm/views/actions/create.php
+++ b/views/admin/orm/views/actions/create.php
@@ -6,5 +6,3 @@
 		<?php echo '<?php'; ?> echo render('<?php echo $view_path; ?>/_form'); ?>
 	</div>
 </div>
-
-<p><?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri ?>', 'Back'); <?php echo '?>'; ?></p>

--- a/views/admin/orm/views/actions/edit.php
+++ b/views/admin/orm/views/actions/edit.php
@@ -1,7 +1,12 @@
 <h2>Editing <?php echo \Str::ucfirst($singular_name); ?></h2>
 <br>
 
-<?php echo '<?php'; ?> echo render('<?php echo $view_path; ?>/_form'); ?>
+<div class="row">
+	<div class="col-md-6">
+		<?php echo '<?php'; ?> echo render('<?php echo $view_path; ?>/_form'); ?>
+	</div>
+</div>
+
 <p>
 	<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$<?php echo $singular_name; ?>->id, 'View'); <?php echo '?>'; ?> |
 	<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>', 'Back'); <?php echo '?>'; ?>

--- a/views/admin/orm/views/actions/edit.php
+++ b/views/admin/orm/views/actions/edit.php
@@ -6,8 +6,3 @@
 		<?php echo '<?php'; ?> echo render('<?php echo $view_path; ?>/_form'); ?>
 	</div>
 </div>
-
-<p>
-	<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$<?php echo $singular_name; ?>->id, 'View'); <?php echo '?>'; ?> |
-	<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>', 'Back'); <?php echo '?>'; ?>
-</p>

--- a/views/admin/orm/views/actions/index.php
+++ b/views/admin/orm/views/actions/index.php
@@ -2,34 +2,36 @@
 <br>
 <?php echo "<?php if (\${$plural_name}): ?>"; ?>
 
-<table class="table table-striped">
-	<thead>
-		<tr>
-<?php foreach ($fields as $field): ?>
-			<th><?php echo \Inflector::humanize($field['name']); ?></th>
-<?php endforeach; ?>
-			<th></th>
-		</tr>
-	</thead>
-	<tbody>
-<?php echo '<?php'; ?> foreach ($<?php echo $plural_name; ?> as $item): <?php echo '?>'; ?>
-		<tr>
+<div class="table-responsive">
+	<table class="table table-striped">
+		<thead>
+			<tr>
+	<?php foreach ($fields as $field): ?>
+				<th><?php echo \Inflector::humanize($field['name']); ?></th>
+	<?php endforeach; ?>
+				<th></th>
+			</tr>
+		</thead>
+		<tbody>
+	<?php echo '<?php'; ?> foreach ($<?php echo $plural_name; ?> as $item): <?php echo '?>'; ?>
+			<tr>
 
-<?php foreach ($fields as $field): ?>
-			<td><?php echo '<?php'; ?> echo $item<?php echo '->'.$field['name']; ?>; <?php echo '?>'; ?></td>
-<?php endforeach; ?>
-			<td>
-				<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$item->id, 'View', array('class' => 'btn btn-xs btn-link')); <?php echo '?>'; ?>
-				<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/edit/'.$item->id, 'Edit', array('class' => 'btn btn-xs btn-link')); <?php echo '?>'; ?>
-				<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/delete/'.$item->id, 'Delete', array('class' => 'btn btn-xs btn-link', 'onclick' => "return confirm('Are you sure?')")); <?php echo '?>'; ?>
+	<?php foreach ($fields as $field): ?>
+				<td><?php echo '<?php'; ?> echo $item<?php echo '->'.$field['name']; ?>; <?php echo '?>'; ?></td>
+	<?php endforeach; ?>
+				<td>
+					<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$item->id, 'View', array('class' => 'btn btn-xs btn-link')); <?php echo '?>'; ?>
+					<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/edit/'.$item->id, 'Edit', array('class' => 'btn btn-xs btn-link')); <?php echo '?>'; ?>
+					<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/delete/'.$item->id, 'Delete', array('class' => 'btn btn-xs btn-link', 'onclick' => "return confirm('Are you sure?')")); <?php echo '?>'; ?>
 
 
-			</td>
-		</tr>
-<?php echo '<?php endforeach; ?>'; ?>
+				</td>
+			</tr>
+	<?php echo '<?php endforeach; ?>'; ?>
 
-	</tbody>
-</table>
+		</tbody>
+	</table>
+</div>
 
 <?php echo '<?php'; ?> echo $pagination <?php echo '?>'; ?>
 

--- a/views/admin/orm/views/actions/index.php
+++ b/views/admin/orm/views/actions/index.php
@@ -1,47 +1,41 @@
 <h2>Listing <?php echo \Str::ucfirst($plural_name); ?></h2>
 <br>
-<?php echo "<?php if (\${$plural_name}): ?>"; ?>
 
-<div class="table-responsive">
-	<table class="table table-striped">
-		<thead>
-			<tr>
-	<?php foreach ($fields as $field): ?>
-				<th><?php echo \Inflector::humanize($field['name']); ?></th>
-	<?php endforeach; ?>
-				<th></th>
-			</tr>
-		</thead>
-		<tbody>
-	<?php echo '<?php'; ?> foreach ($<?php echo $plural_name; ?> as $item): <?php echo '?>'; ?>
-			<tr>
+<?php echo "<?php if (\${$plural_name}): ?>".PHP_EOL; ?>
+	<div class="table-responsive">
+		<table class="table table-striped">
+			<thead>
+				<tr>
+<?php foreach ($fields as $field): ?>
+					<th><?php echo \Inflector::humanize($field['name']); ?></th>
+<?php endforeach; ?>
+					<th></th>
+				</tr>
+			</thead>
 
-	<?php foreach ($fields as $field): ?>
-				<td><?php echo '<?php'; ?> echo $item<?php echo '->'.$field['name']; ?>; <?php echo '?>'; ?></td>
-	<?php endforeach; ?>
-				<td>
-					<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$item->id, 'View', array('class' => 'btn btn-xs btn-link')); <?php echo '?>'; ?>
-					<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/edit/'.$item->id, 'Edit', array('class' => 'btn btn-xs btn-link')); <?php echo '?>'; ?>
-					<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/delete/'.$item->id, 'Delete', array('class' => 'btn btn-xs btn-link', 'onclick' => "return confirm('Are you sure?')")); <?php echo '?>'; ?>
+			<tbody>
+				<?php echo '<?php'; ?> foreach ($<?php echo $plural_name; ?> as $item): <?php echo '?>'.PHP_EOL; ?>
+					<tr>
+<?php foreach ($fields as $field): ?>
+						<td><?php echo '<?php'; ?> echo $item<?php echo '->'.$field['name']; ?>; <?php echo '?>'; ?></td>
+<?php endforeach; ?>
 
+						<td>
+							<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$item->id, 'View'); <?php echo '?>'; ?> |
+							<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/edit/'.$item->id, 'Edit'); <?php echo '?>'; ?> |
+							<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/delete/'.$item->id, 'Delete', array('onclick' => "return confirm('Are you sure?')")); <?php echo '?>'.PHP_EOL; ?>
+						</td>
+					</tr>
+				<?php echo '<?php endforeach; ?>'.PHP_EOL; ?>
+			</tbody>
+		</table>
+	</div>
 
-				</td>
-			</tr>
-	<?php echo '<?php endforeach; ?>'; ?>
+	<?php echo '<?php'; ?> echo $pagination <?php echo '?>'.PHP_EOL; ?>
+<?php echo '<?php else: ?>'.PHP_EOL; ?>
+	<p>No <?php echo \Str::ucfirst($plural_name); ?>.</p>
+<?php echo '<?php endif; ?>'.PHP_EOL; ?>
 
-		</tbody>
-	</table>
-</div>
-
-<?php echo '<?php'; ?> echo $pagination <?php echo '?>'; ?>
-
-<?php echo '<?php else: ?>'; ?>
-
-<p>No <?php echo \Str::ucfirst($plural_name); ?>.</p>
-
-<?php echo '<?php endif; ?>'; ?>
 <p>
-	<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/create', 'Add new <?php echo \Inflector::humanize($singular_name); ?>', array('class' => 'btn btn-success')); <?php echo '?>'; ?>
-
-
+	<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/create', 'Add new <?php echo \Inflector::humanize($singular_name); ?>', array('class' => 'btn btn-success')); <?php echo '?>'.PHP_EOL; ?>
 </p>

--- a/views/admin/orm/views/actions/index.php
+++ b/views/admin/orm/views/actions/index.php
@@ -19,9 +19,9 @@
 			<td><?php echo '<?php'; ?> echo $item<?php echo '->'.$field['name']; ?>; <?php echo '?>'; ?></td>
 <?php endforeach; ?>
 			<td>
-				<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$item->id, 'View'); <?php echo '?>'; ?> |
-				<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/edit/'.$item->id, 'Edit'); <?php echo '?>'; ?> |
-				<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/delete/'.$item->id, 'Delete', array('onclick' => "return confirm('Are you sure?')")); <?php echo '?>'; ?>
+				<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/view/'.$item->id, 'View', array('class' => 'btn btn-xs btn-link')); <?php echo '?>'; ?>
+				<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/edit/'.$item->id, 'Edit', array('class' => 'btn btn-xs btn-link')); <?php echo '?>'; ?>
+				<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri; ?>/delete/'.$item->id, 'Delete', array('class' => 'btn btn-xs btn-link', 'onclick' => "return confirm('Are you sure?')")); <?php echo '?>'; ?>
 
 
 			</td>

--- a/views/admin/orm/views/actions/view.php
+++ b/views/admin/orm/views/actions/view.php
@@ -1,11 +1,15 @@
 <h2>Viewing #<?php echo '<?php'; ?> echo $<?php echo $singular_name; ?>->id; <?php echo '?>'; ?></h2>
+<br>
 
+<dl class="dl-horizontal">
 <?php foreach ($fields as $field): ?>
-<p>
-	<strong><?php echo \Inflector::humanize($field['name']); ?>:</strong>
-	<?php echo '<?php'; ?> echo $<?php echo $singular_name.'->'.$field['name']; ?>; <?php echo '?>'; ?>
-</p>
+	<dt><?php echo \Inflector::humanize($field['name']); ?></dt>
+	<dd><?php echo '<?php'; ?> echo $<?php echo $singular_name.'->'.$field['name']; ?>; <?php echo '?>'; ?></dd>
+	<br>
 <?php endforeach; ?>
+</dl>
 
-<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri ?>/edit/'.$<?php echo $singular_name; ?>->id, 'Edit'); <?php echo '?>'; ?> |
-<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri ?>', 'Back'); <?php echo '?>'; ?>
+<div class="btn-group">
+	<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri ?>/edit/'.$<?php echo $singular_name; ?>->id, 'Edit', array('class' => 'btn btn-warning')); <?php echo '?>'.PHP_EOL; ?>
+	<?php echo '<?php'; ?> echo Html::anchor('<?php echo $uri ?>', 'Back', array('class' => 'btn btn-default')); <?php echo '?>'.PHP_EOL; ?>
+</div>

--- a/views/admin/template.php
+++ b/views/admin/template.php
@@ -11,9 +11,6 @@
 		'http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js',
 		'bootstrap.js',
 	)); ?>
-	<script>
-		$(function(){ $('.topbar').dropdown(); });
-	</script>
 </head>
 <body>
 

--- a/views/admin/template.php
+++ b/views/admin/template.php
@@ -1,99 +1,108 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title><?php echo $title; ?></title>
-	<?php echo Asset::css('bootstrap.css'); ?>
-	<style>
-		body { margin-top: 50px; }
-	</style>
-</head>
-<body>
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	<?php if ($current_user): ?>
-	<div class="navbar navbar-inverse navbar-fixed-top">
-		<div class="container">
-			<div class="navbar-header">
-				<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-					<span class="icon-bar"></span>
-					<span class="icon-bar"></span>
-					<span class="icon-bar"></span>
-				</button>
-				<a class="navbar-brand" href="#">My Site</a>
-			</div>
-			<div class="navbar-collapse collapse">
-				<ul class="nav navbar-nav">
-					<li class="<?php echo Uri::segment(2) == '' ? 'active' : '' ?>">
-						<?php echo Html::anchor('admin', 'Dashboard') ?>
-					</li>
+		<title><?php echo $title; ?></title>
 
-					<?php
-						foreach(new GlobIterator(APPPATH.'classes/controller/admin/*.php') as $file)
-						{
-							$section_segment = $file->getBasename('.php');
-							$section_title = Inflector::humanize($section_segment);
-							?>
-							<li class="<?php echo Uri::segment(2) == $section_segment ? 'active' : '' ?>">
-								<?php echo Html::anchor('admin/'.$section_segment, $section_title) ?>
+		<?php echo Asset::css('bootstrap.css'); ?>
+
+		<style>
+			body { margin-top: 50px; }
+		</style>
+	</head>
+
+	<body>
+		<?php if ($current_user): ?>
+			<div class="navbar navbar-inverse navbar-fixed-top">
+				<div class="container">
+					<div class="navbar-header">
+						<button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+							<span class="icon-bar"></span>
+							<span class="icon-bar"></span>
+							<span class="icon-bar"></span>
+						</button>
+						<a class="navbar-brand" href="#">My Site</a>
+					</div>
+
+					<div class="navbar-collapse collapse">
+						<ul class="nav navbar-nav">
+							<li class="<?php echo Uri::segment(2) == '' ? 'active' : '' ?>">
+								<?php echo Html::anchor('admin', 'Dashboard') ?>
 							</li>
-							<?php
-						}
-					?>
-				</ul>
-				<ul class="nav navbar-nav navbar-right">
-					<li class="dropdown">
-						<a data-toggle="dropdown" class="dropdown-toggle" href="#"><?php echo $current_user->username ?> <b class="caret"></b></a>
-						<ul class="dropdown-menu dropdown-menu-right">
-							<li><?php echo Html::anchor('admin/logout', 'Logout') ?></li>
-						</ul>
-					</li>
-				</ul>
-			</div>
-		</div>
-	</div>
-	<?php endif; ?>
 
-	<div class="container">
-		<div class="row">
-			<div class="col-md-12">
-				<h1><?php echo $title; ?></h1>
-				<hr>
-<?php if (Session::get_flash('success')): ?>
-				<div class="alert alert-success alert-dismissable">
-					<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-					<p>
-					<?php echo implode('</p><p>', (array) Session::get_flash('success')); ?>
-					</p>
+							<?php
+								foreach (new GlobIterator(APPPATH.'classes/controller/admin/*.php') as $file)
+								{
+									$section_segment = $file->getBasename('.php');
+									$section_title = Inflector::humanize($section_segment);
+							?>
+									<li class="<?php echo Uri::segment(2) == $section_segment ? 'active' : '' ?>">
+										<?php echo Html::anchor('admin/'.$section_segment, $section_title) ?>
+									</li>
+							<?php
+								}
+							?>
+						</ul>
+
+						<ul class="nav navbar-nav navbar-right">
+							<li class="dropdown">
+								<a data-toggle="dropdown" class="dropdown-toggle" href="#"><?php echo $current_user->username ?> <b class="caret"></b></a>
+								<ul class="dropdown-menu dropdown-menu-right">
+									<li><?php echo Html::anchor('admin/logout', 'Logout') ?></li>
+								</ul>
+							</li>
+						</ul>
+					</div>
 				</div>
-<?php endif; ?>
-<?php if (Session::get_flash('error')): ?>
-				<div class="alert alert-danger alert-dismissable">
-					<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-					<p>
-					<?php echo implode('</p><p>', (array) Session::get_flash('error')); ?>
-					</p>
+			</div>
+		<?php endif; ?>
+
+		<div class="container">
+			<div class="row">
+				<div class="col-md-12">
+					<h1><?php echo $title; ?></h1>
+					<hr>
+
+					<?php if (Session::get_flash('success')): ?>
+						<div class="alert alert-success alert-dismissable">
+							<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+							<p>
+							<?php echo implode('</p><p>', (array) Session::get_flash('success')); ?>
+							</p>
+						</div>
+					<?php endif; ?>
+
+					<?php if (Session::get_flash('error')): ?>
+					<div class="alert alert-danger alert-dismissable">
+						<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+						<p>
+						<?php echo implode('</p><p>', (array) Session::get_flash('error')); ?>
+						</p>
+					</div>
+					<?php endif; ?>
 				</div>
-<?php endif; ?>
+
+				<div class="col-md-12">
+					<?php echo $content; ?>
+				</div>
 			</div>
-			<div class="col-md-12">
-<?php echo $content; ?>
-			</div>
+
+			<hr/>
+			<footer>
+				<p class="pull-right">Page rendered in {exec_time}s using {mem_usage}mb of memory.</p>
+				<p>
+					<a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.<br>
+					<small>Version: <?php echo e(Fuel::VERSION); ?></small>
+				</p>
+			</footer>
 		</div>
-		<hr/>
-		<footer>
-			<p class="pull-right">Page rendered in {exec_time}s using {mem_usage}mb of memory.</p>
-			<p>
-				<a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.<br>
-				<small>Version: <?php echo e(Fuel::VERSION); ?></small>
-			</p>
-		</footer>
-	</div>
-	
-	<?php echo Asset::js(array(
-		'http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js',
-		'bootstrap.js',
-	)); ?>
-</body>
+		
+		<?php echo Asset::js(array(
+			'http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js',
+			'bootstrap.js',
+		)); ?>
+	</body>
 </html>

--- a/views/admin/template.php
+++ b/views/admin/template.php
@@ -47,7 +47,7 @@
 				<ul class="nav navbar-nav pull-right">
 					<li class="dropdown">
 						<a data-toggle="dropdown" class="dropdown-toggle" href="#"><?php echo $current_user->username ?> <b class="caret"></b></a>
-						<ul class="dropdown-menu">
+						<ul class="dropdown-menu dropdown-menu-right">
 							<li><?php echo Html::anchor('admin/logout', 'Logout') ?></li>
 						</ul>
 					</li>

--- a/views/admin/template.php
+++ b/views/admin/template.php
@@ -44,7 +44,7 @@
 						}
 					?>
 				</ul>
-				<ul class="nav navbar-nav pull-right">
+				<ul class="nav navbar-nav navbar-right">
 					<li class="dropdown">
 						<a data-toggle="dropdown" class="dropdown-toggle" href="#"><?php echo $current_user->username ?> <b class="caret"></b></a>
 						<ul class="dropdown-menu dropdown-menu-right">

--- a/views/admin/template.php
+++ b/views/admin/template.php
@@ -9,10 +9,6 @@
 	<style>
 		body { margin-top: 50px; }
 	</style>
-	<?php echo Asset::js(array(
-		'http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js',
-		'bootstrap.js',
-	)); ?>
 </head>
 <body>
 
@@ -94,5 +90,10 @@
 			</p>
 		</footer>
 	</div>
+	
+	<?php echo Asset::js(array(
+		'http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js',
+		'bootstrap.js',
+	)); ?>
 </body>
 </html>

--- a/views/admin/template.php
+++ b/views/admin/template.php
@@ -5,7 +5,7 @@
 	<title><?php echo $title; ?></title>
 	<?php echo Asset::css('bootstrap.css'); ?>
 	<style>
-		body { margin: 50px; }
+		body { margin-top: 50px; }
 	</style>
 	<?php echo Asset::js(array(
 		'http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js',

--- a/views/admin/template.php
+++ b/views/admin/template.php
@@ -2,6 +2,8 @@
 <html>
 <head>
 	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title><?php echo $title; ?></title>
 	<?php echo Asset::css('bootstrap.css'); ?>
 	<style>


### PR DESCRIPTION
Hello, I want to propose some changes on generating code from `oil g admin` command. BTW, forgive me for the long explanation here 🙇🏻‍♂️

---

## Commit c5c57f1

Current style is using `margin` instead of `margin-top`. This creates unnecessary space when viewed on phones.

### Process

1. Open the page with Responsive Design Mode
2. Select any phone display

### Current  result

![a web page viewed on phone with margin on all sides](https://user-images.githubusercontent.com/3760093/52798290-37c8f080-30aa-11e9-80da-cd9ee9f641fd.png)

## Proposed result

![a web page viewed on phone with margin for top side](https://user-images.githubusercontent.com/3760093/52798661-f5ec7a00-30aa-11e9-8238-d578fc9f8d2b.png)

---

## Commit 7684d58

There are some code which look like activating dropdown functionality on navbar. But, when I tried to remove it, I still can use dropdown functionality on navbar. So, I think it is best to remove it.

---

## Commit 20be5dc

The dropdown menu is aligned to left while it is on the most right side of navbar. I think it is better to aligned to right.

### Current result

![dropdown on the right side with menu aligned in left](https://user-images.githubusercontent.com/3760093/52799268-110bb980-30ac-11e9-9c1a-c64b02cd13aa.png)

### Proposed result

![dropdown on the right side with menu aligned in right](https://user-images.githubusercontent.com/3760093/52799358-3c8ea400-30ac-11e9-800a-3347671a5526.png)

---

## Commit e4800cf

The form inputs and labels are overflowed from container width. I think it was caused by `form` element using `form-horizontal` class.

### Current result

![form with overflowed input width](https://user-images.githubusercontent.com/3760093/52799684-ec641180-30ac-11e9-91fc-6a652ab4b4af.png)

### Proposed result

![form with appropriate input width](https://user-images.githubusercontent.com/3760093/52799752-10275780-30ad-11e9-9859-cbbaef7e7f7a.png)

---

## Commit 573f6fd

The form is always full width on any screen display. I think it will be better if we only use half of the page width for the form in large screen display.

### Current result

![form with appropriate input width](https://user-images.githubusercontent.com/3760093/52799752-10275780-30ad-11e9-9859-cbbaef7e7f7a.png)

### Proposed result

![form for add new article with half width of the page on large screen display](https://user-images.githubusercontent.com/3760093/52800224-e3277480-30ad-11e9-9d19-83672901f0e5.png)

![form for edit article with half width of the page on large screen display](https://user-images.githubusercontent.com/3760093/52800448-59c47200-30ae-11e9-833b-091ee02611c3.png)

---

## Commit 5423309

I think it would be better if the Back and View button are relocated on the right of Save button instead of on the below of Save button.

### Current result

![form for add new article with back button below of save button](https://user-images.githubusercontent.com/3760093/52800224-e3277480-30ad-11e9-9d19-83672901f0e5.png)

![form for edit article with back and view buttons below of the save button](https://user-images.githubusercontent.com/3760093/52800448-59c47200-30ae-11e9-833b-091ee02611c3.png)

### Proposed result

![form for add new article with back button on the right of save button](https://user-images.githubusercontent.com/3760093/52800843-2f26e900-30af-11e9-93ad-169656f81132.png)

![form for edit article with back and view buttons on the right of the save button](https://user-images.githubusercontent.com/3760093/52800886-4cf44e00-30af-11e9-8c68-210b3eafe518.png)

---

## Commit 6e5de83

Action buttons (View, Edit and Delete) is too compact. I think adding a little space for larger clickable area would be better

### Current result

![compact action buttons](https://user-images.githubusercontent.com/3760093/52801122-d441c180-30af-11e9-86a2-db563f3c8d60.png)

### Proposed result

![action buttons with larger clickable area](https://user-images.githubusercontent.com/3760093/52801196-f3d8ea00-30af-11e9-8233-ff71029d3828.png)

---

## Commit 87ca140

Responsive table is common nowadays. So, I want to implement it here too.

### Current result

![unresponsive table](https://user-images.githubusercontent.com/3760093/52801626-e5d79900-30b0-11e9-8abb-158d5c5f995b.png)

### Proposed result

![responsive table](https://user-images.githubusercontent.com/3760093/52801696-0869b200-30b1-11e9-9c11-0d3d2edeea44.png)

---

## Commit a241632

On phone screen, the dropdown menu width for log out is not displayed properly.

### Current result

![not full width dropdown menu for log out on phone screen](https://user-images.githubusercontent.com/3760093/52801929-7ada9200-30b1-11e9-836a-a92041b74512.png)

### Proposed result

![full width dropdown menu for log out on phone screen](https://user-images.githubusercontent.com/3760093/52802017-a198c880-30b1-11e9-9f57-0bea274d15ec.png)

---

## Commit 9738920

Add recommended meta tags for responsiveness based on [Bootstrap example](https://getbootstrap.com/docs/3.4/getting-started/#template)

---

## Commit 84fdb22

Move `script` tags on the bottom of `body` for better web page rendering speed

---

## Commit 11e9616

Tidying template file for admin

---

## Commit b6c5dfb

Tidying generate code for index page

### Current result

![code for index page which not so tidy](https://user-images.githubusercontent.com/3760093/52802427-7b275d00-30b2-11e9-99fe-1f1db0ddd86d.png)

### Proposed result

![code for index page which is tidier](https://user-images.githubusercontent.com/3760093/52802542-c04b8f00-30b2-11e9-9798-a947a490c076.png)

---

## Commit  bb53a75

Tidying output code for add and edit form

### Current result

![untidied add and edit form](https://user-images.githubusercontent.com/3760093/52802720-16203700-30b3-11e9-83cf-1fe332db2d73.png)

![tidied add and edit form](https://user-images.githubusercontent.com/3760093/52802994-9f376e00-30b3-11e9-841f-01ce3c5326f3.png)

---

## Commit f567db4

Beautify view details page using `dl` style

### Current result

![standard view details page](https://user-images.githubusercontent.com/3760093/52803177-1836c580-30b4-11e9-980f-3e93b5cd9830.png)

### Proposed result

![view details page with new style](https://user-images.githubusercontent.com/3760093/52803528-d4908b80-30b4-11e9-96e4-74c74bc96dbd.png)
