### PR TITLE
Allow oil test to run on modern version of PHPUnit

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -184,7 +184,7 @@ HELP;
 						@include_once $phpunit_autoload_path;
 
 						// Attempt to load PHUnit.  If it fails, we are done.
-						if ( ! $is_phar and ! class_exists('PHPUnit_Framework_TestCase'))
+						if ( ! $is_phar and ! (class_exists('PHPUnit_Framework_TestCase') or class_exists('PHPUnit\Framework\TestCase')))
 						{
 							throw new Exception('PHPUnit does not appear to be installed.'.PHP_EOL.PHP_EOL."\tPlease visit https://phpunit.de and install.");
 						}


### PR DESCRIPTION
Not a huge fan of 'and' and 'or' syntax in the conditionals but that seems to be the style of the file!

This will allow you to composer require phpunit/phpunit, update app/config/oil.php paths and run php oil test on versions of PHPUnit greater than 6!