### PR TITLE
PHP 8.1 compatability when phpunit autoload file doesnt exit

### DIFF
--- a/classes/command.php
+++ b/classes/command.php
@@ -181,7 +181,10 @@ HELP;
 						// Suppressing this because if the file does not exist... well thats a bad thing and we can't really check
 						// I know that supressing errors is bad, but if you're going to complain: shut up. - Phil
 						$phpunit_autoload_path = \Config::get('oil.phpunit.autoload_path', 'PHPUnit/Autoload.php' );
-						@include_once $phpunit_autoload_path;
+						if (file_exists($phpunit_autoload_path))
+						{
+							include_once $phpunit_autoload_path;
+						}
 
 						// Attempt to load PHUnit.  If it fails, we are done.
 						if ( ! $is_phar and ! (class_exists('PHPUnit_Framework_TestCase') or class_exists('PHPUnit\Framework\TestCase')))


### PR DESCRIPTION
Oil attempts to load phpunit's autoload file, ignoring failures if it isn't able to load the file.  The code is currently using the @ operator to suppress errors in loading the file.

Here's the error caused by running phpUnit on https://github.com/ucfopen/Materia on php 8.1
```
Uncaught exception Fuel\Core\PhpErrorException: 2 - include_once(PHPUnit/Autoload.php): Failed to open stream: No such file or directory in /var/www/html/fuel/packages/oil/classes/command.php on line 184
```

This change will check if the file exists as a gate in front of loading it, which will prevent the error that is no longer suppressed in php 8.1

